### PR TITLE
edited function getCellNumbers because  was hard-coded in the functio…

### DIFF
--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -296,6 +296,12 @@ cat("Importing metadata ... ")
 metadata <- read.table(opt$metadata, sep="\t", header=TRUE, as.is=TRUE)
 cat("Done.\n")
 
+# ensure that the barcode column is present in the metadata
+if (!"barcode" %in% colnames(s@meta.data)) {
+    stop('Mandatory "barcode" column missing from the metadata')
+}
+
+
 rownames(metadata) <- metadata$barcode
 metadata$barcode <- NULL
 

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -209,9 +209,12 @@ print(opt)
 #' @param stage Character value to tag the new entry.
 #'
 #' @return A data.frame
-getCellNumbers <- function(s, cell_numbers="none", stage="input") {
+getCellNumbers <- function(s, cell_numbers="none", stage="input",
+	       	  	   groupby=groupby) {
     ## cell_info <- getCellInfo(s)
-    counts <- as.data.frame(table(s@meta.data$sample_id))
+    if ( is.null(groupby) ) {
+    	groupby <- "sample_id" }
+    counts <- as.data.frame(table(s@meta.data[, groupby]))
     colnames(counts) <- c("sample_id", stage)
     rownames(counts) <- counts$sample_id
     counts$sample_id <- NULL
@@ -437,7 +440,7 @@ save_plots(
     )
 
 # TODO: Document
-cell_numbers <- getCellNumbers(s)
+cell_numbers <- getCellNumbers(s, groupby=groupby)
 
 ## We filter out cells that have unique gene counts over 2,500
 ## Note that accept.high and accept.low can be used to define a 'gate',
@@ -460,7 +463,8 @@ s <- FilterCells(
 
 stats$no_cells_after_qc <- ncol(s@data)
 
-cell_numbers <- getCellNumbers(s, cell_numbers=cell_numbers, stage="after_qc_filters")
+cell_numbers <- getCellNumbers(s, cell_numbers=cell_numbers, stage="after_qc_filters",
+	     		       groupby=groupby)
 
 cat("Data dimensions after subsetting:\n")
 print(dim(s@data))
@@ -491,7 +495,8 @@ if (as.logical(opt$downsamplecells)) {
     s <- SubsetData(s, cells.use=cells.to.use)
 
     ##cell_info <- getCellInfo(s)
-    cell_numbers <- getCellNumbers(s, cell_numbers=cell_numbers, stage="after_downsampling")
+    cell_numbers <- getCellNumbers(s, cell_numbers=cell_numbers,
+    		    		   stage="after_downsampling", groupby=groupby)
     cat("Numbers of cells per sample after down-sampling:\n")
     print(cell_numbers)
 }

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -431,6 +431,7 @@ save_plots(
     )
 
 # TODO: Document
+
 cell_numbers <- getCellNumbers(s, groupby=opt$groupby)
 
 ## We filter out cells that have unique gene counts over 2,500
@@ -484,6 +485,7 @@ if (as.logical(opt$downsamplecells)) {
     ##cell_info <- getCellInfo(s)
     cell_numbers <- getCellNumbers(s, cell_numbers=cell_numbers,
     		    		   stage="after_downsampling", groupby=opt$groupby)
+
     cat("Numbers of cells per sample after down-sampling:\n")
     print(cell_numbers)
 }

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -513,44 +513,120 @@ s <- NormalizeData(
 latent.vars <- strsplit(opt$latentvars, ",")[[1]]
 print(latent.vars)
 
-if ( identical(opt$cellcycle, "none") ) {
-    ## vars.to.regress <- latent.vars
-    ## s <- ScaleData(object=s, vars.to.regress=latent.vars,
-    ##                model.use=opt$modeluse)
-    cat("Data wil be scaled without correcting for cell cycle\n")
+
+# perform regression without cell cycle correction
+s <- ScaleData(object=s, vars.to.regress=latent.vars,
+               model.use=opt$modeluse)
+
+
+## initialise the text snippet
+tex = ""
+
+## start building figure latex...
+subsectionTitle <- getSubsectionTex("Visualisation of cell cycle effects")
+tex <- c(tex, subsectionTitle)
+
+
+## If cell cycle genes are given, make a PCA of the cells based
+## on expression of cell cycle genes
+
+cell_cycle_genes <- FALSE
+
+if (!is.null(opt$sgenes) & !is.null(opt$g2mgenes)){
+
+  cell_cycle_genes <- TRUE
+  cat("There are cell cycle genes")
+
+  # get the genes representing the cell cycle phases
+  sgenes_ensembl <- read.table(opt$sgenes, header=F, as.is=T)$V1
+  sgenes <- s@misc$seurat_id[s@misc$gene_id %in% sgenes_ensembl]
+
+  g2mgenes_ensembl <- read.table(opt$g2mgenes, header=F, as.is=T)$V1
+  g2mgenes <- s@misc$seurat_id[s@misc$gene_id %in% g2mgenes_ensembl]
+
+  # score the cell cycle phases
+  s <- CellCycleScoring(
+    object=s, s.genes=sgenes, g2m.genes=g2mgenes, set.ident=TRUE
+  )
+
+  s <- RunPCA(object = s, pc.genes = c(sgenes, g2mgenes), do.print = FALSE)
+
+  ## PCA plot on cell cycle genes without regression
+  gp <- PCAPlot(object = s)
+
+  cc_plot_fn <- "cellcycle.without.regression.pca"
+  cc_plot_path <- file.path(opt$outdir, cc_plot_fn)
+
+  save_ggplots(cc_plot_path, gp, width=7, height=4)
+
+  pcaCaption <- paste0("PCA analysis of cells based on expression of cell cycle genes ",
+                       "(without regression of cell-cyle effects)")
+
+  tex <- c(tex, getFigureTex(cc_plot_fn,
+                             pcaCaption,
+                             plot_dir_var="runDir"))
+
 } else {
-    # get the genes representing the cell cycle phases
-    sgenes_ensembl <- read.table(opt$sgenes, header=F, as.is=T)$V1
-    sgenes <- s@misc$seurat_id[s@misc$gene_id %in% sgenes_ensembl]
-
-    g2mgenes_ensembl <- read.table(opt$g2mgenes, header=F, as.is=T)$V1
-    g2mgenes <- s@misc$seurat_id[s@misc$gene_id %in% g2mgenes_ensembl]
-
-    # score the cell cycle phases
-    s <- CellCycleScoring(
-        object=s, s.genes=sgenes, g2m.genes=g2mgenes, set.ident=TRUE
-        )
-
-    if ( identical(opt$cellcycle, "all") ) {
-        ## regress out all cell cycle effects
-        latent.vars <- c(latent.vars, "S.Score", "G2M.Score")
-        ## s <- ScaleData(object=s, vars.to.regress=c(latent.vars, "S.Score", "G2M.Score"),
-        ##               model.use=opt$modeluse)
-        cat("Scaling will include removal of all cell cycle variation\n")
-    } else if ( identical(opt$cellcycle, "difference") ) {
-        ## regress out the difference between G2M and S phase scores
-        s@meta.data$CC.Difference <- s@meta.data$S.Score - s@meta.data$G2M.Score
-
-        latent.vars <- c(latent.vars, "CC.Difference")
-        ## s <- ScaleData(object=s, vars.to.regress=c(latent.vars, "CC.Difference"),
-        ##                model.use=opt$modeluse)
-        cat("Scaling included removal of difference between G2M and S phase scores\n")
-    } else {
-        stop("cellcycle regression type not understood")
-    }
+    tex <- c(tex, "Cell cycle genelists not supplied.")
 }
 
-s <- ScaleData(object=s, vars.to.regress=latent.vars, model.use=opt$modeluse)
+## Perform regression (with or without cell cycle correction)
+if ( identical(opt$cellcycle, "none") ) {
+
+    cat("Data was scaled without correcting for cell cycle")
+
+} else {
+
+    if (!cell_cycle_genes){
+        stop("Please provide lists of cell cycle sgenes and g2mgenes")
+        }
+
+
+    if ( identical(opt$cellcycle, "all") ){
+
+      ## regress out all cell cycle effects
+      s <- ScaleData(object=s, vars.to.regress=c(latent.vars, "S.Score", "G2M.Score"),
+                     model.use=opt$modeluse)
+
+        cat("Data was scaled to remove all cell cycle variation\n")
+
+    } else if ( identical(opt$cellcycle, "difference") ) {
+
+      ## regress out the difference between G2M and S phase scores
+      s@meta.data$CC.Difference <- s@meta.data$S.Score - s@meta.data$G2M.Score
+      s <- ScaleData(object=s, vars.to.regress=c(latent.vars, "CC.Difference"),
+                     model.use=opt$modeluse)
+
+      cat("Scaling was scaled to remove the difference between G2M and S phase scores\n")
+    } else {
+      stop("cellcycle regression type not understood")
+    }
+
+    ## visualise the cells by PCA of cell cycle genes after regression
+    s <- RunPCA(object = s, pc.genes = c(sgenes, g2mgenes), do.print = FALSE)
+    gp <- PCAPlot(object = s)
+
+    cc_plot_fn <- paste("cellcycle.regressed", opt$cellcycle, "pca", sep=".")
+    cc_plot_path <- file.path(opt$outdir, cc_plot_fn)
+
+    save_ggplots(cc_plot_path, gp, width=7, height=4)
+
+    pcaCaption <- paste0("PCA analysis of cells based on expression of cell cycle genes ",
+                         "after regression of cell-cyle effects ",
+                         "(regression type: ", opt$cellcycle, ")")
+
+    tex <- c(tex, getFigureTex(cc_plot_fn,
+                               pcaCaption,
+                               plot_dir_var="runDir"))
+
+}
+
+
+
+tex_file <- file.path(opt$outdir, "cell.cycle.tex")
+
+writeTex(tex_file, tex)
+
 
 
 ## ######################################################################### ##

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -297,10 +297,9 @@ metadata <- read.table(opt$metadata, sep="\t", header=TRUE, as.is=TRUE)
 cat("Done.\n")
 
 # ensure that the barcode column is present in the metadata
-if (!"barcode" %in% colnames(s@meta.data)) {
+if (!"barcode" %in% colnames(metadata)) {
     stop('Mandatory "barcode" column missing from the metadata')
 }
-
 
 rownames(metadata) <- metadata$barcode
 metadata$barcode <- NULL

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -224,13 +224,22 @@ def beginSeurat(infile, outfile):
     else:
         subset = ""
 
-    if PARAMS["regress_cellcycle"] != "none":
-        cell_cycle = '''--cellcycle=%(regress_cellcycle)s
-                        --sgenes=%(regress_sgenes)s
-                        --g2mgenes=%(regress_g2mgenes)s
-                     ''' % PARAMS
+    if ( os.path.isfile(PARAMS["cellcycle_sgenes"]) and
+         os.path.isfile(PARAMS["cellcycle_g2mgenes"]) ):
+
+        cell_cycle_genes = '''--sgenes=%(cellcycle_sgenes)s
+                              --g2mgenes=%(cellcycle_g2mgenes)s
+                           ''' % PARAMS
+
     else:
-        cell_cycle = ""
+        cell_cycle_genes = ""
+
+
+    if PARAMS["regress_cellcycle"] != "none":
+        cell_cycle_regress = '''--cellcycle=%(regress_cellcycle)s
+                             ''' % PARAMS
+    else:
+        cell_cycle_regress = ""
 
     # Turn Python boolean into R logical
     downsamplecells = str(PARAMS["qc_downsamplecells"]).upper()
@@ -252,7 +261,8 @@ def beginSeurat(infile, outfile):
                    --xlowcutoff=%(vargenes_xlowcutoff)s
                    --xhighcutoff=%(vargenes_xhighcutoff)s
                    %(subset)s
-                   %(cell_cycle)s
+                   %(cell_cycle_genes)s
+                   %(cell_cycle_regress)s
                    &> %(log_file)s
                 '''
 

--- a/pipelines/pipeline_seurat/beginReport.tex
+++ b/pipelines/pipeline_seurat/beginReport.tex
@@ -1,7 +1,9 @@
 \section{Data pre-processing}
 \input{\tenxDir/pipelines/pipeline_seurat/qcSection.tex}
 \input{\tenxDir/pipelines/pipeline_seurat/ruvSection.tex}
+\input{\runDir/cell.cycle.tex}
 \input{\tenxDir/pipelines/pipeline_seurat/summaryStatsSection.tex}
+
 
 \section{Feature (gene) selection and dimension reduction}
 

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -99,6 +99,26 @@ qc:
 # Regression parameters
 # ---------------------
 
+cellcycle:
+
+  # If lists of cell cycle genes are supplied
+  # cycle-cycle effects will be visualised by the pipeline.
+  # The lists will also be used for regression if specified below.
+  #
+  # > mouse cell cycle genes >
+  #
+  # sgenes: /gfs/archive/sansom/datasets/cell_cycle/mouse/s_genes.txt
+  # g2mgenes: /gfs/archive/sansom/datasets/cell_cycle/mouse/g2m_genes.txt
+  #
+  # > human cell cycle genes >
+  #
+  # sgenes: /gfs/archive/sansom/datasets/cell_cycle/human/wang.g1-s.txt
+  # g2mgenes: /gfs/archive/sansom/datasets/cell_cycle/human/wang.g2-m.txt
+
+  sgenes: none
+  g2mgenes: none
+
+
 regress:
     ## Removal of unwanted variation (see Seurat::ScaleData)
     # Latent variables to regress out
@@ -112,8 +132,6 @@ regress:
     # - Use "difference" to regress out the difference between G2M and S phase scores
     # (i.e. the Alternate Workflow in the link above)
     cellcycle: none
-    sgenes:
-    g2mgenes:
 
 
 # Variable gene identification parameters
@@ -294,6 +312,10 @@ gmt_files:
   # msigdb_canonical_pathways: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.v6.1.entrez.gmt
   # msigdb_tf_motifs: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c3.tft.v6.1.entrez.gmt
   # msigdb_immunological_signatures: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c7.all.v6.1.entrez.gmt
+  #
+  # > human cell types >
+  #
+  # xCell: /gfs/mirror/xCell/xCell_entrezID.gmt
   #
   # > mouse msigdb sets >
   #


### PR DESCRIPTION
…n, but not indicated in pipeline.yml that grouping has to be done by sample_id.


The function getCellNumbers in seurat_begin.R had “$sample_id” hard-coded. In pipeline.yml, it is not clearly stated that the groupby column has to be sample_id. Therefore I changed the function to be more flexible. In case of “NULL”, the groupby variable is set to “sample_id”. Not sure if this is desired but also unsure what should happen in the case of NULL for groupby variable.