### PR TITLE
Add trendvar hvg identification

### DIFF
--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -702,6 +702,8 @@ s <- FindVariableGenes(
     y.cutoff=opt$sdcutoff, do.plot=FALSE, do.text=FALSE, do.contour=FALSE
 )
 
+xthreshold <- opt$xlowcutoff
+
 if(opt$vargenesmethod=="trendvar")
 {
     message("setting variable genes using the trendvar method")
@@ -725,7 +727,9 @@ if(opt$vargenesmethod=="trendvar")
 
     # overwrite the slot!
     s@var.genes <- row.names(hvg.out)
-    #s@hvg.info <- var.out.nospike
+    ## s@hvg.info <- var.out.nospike
+
+    xthreshold <- opt$minmean
 }
 
 
@@ -743,7 +747,12 @@ gp <- gp + geom_point(alpha = 1, size=0.5)
 gp <- gp + facet_wrap(~variable, scales="free")
 gp <- gp + theme_classic()
 
-save_ggplots(file.path(opt$outdir, "varGenesPlot.png"),
+if(xthreshold > 0)
+{
+    gp <- gp + geom_vline(xintercept=xthreshold, linetype="dashed", color="blue")
+}
+
+save_ggplots(file.path(opt$outdir, "varGenesPlot"),
              gp=gp,
              width=8,
              height=5)

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -23,7 +23,8 @@ stopifnot(
   require(dplyr),
   require(Matrix),
   require(xtable),
-  require(tenxutils)
+  require(tenxutils),
+  require(reshape2)
 )
 
 # Options ----
@@ -160,6 +161,22 @@ option_list <- list(
         help=paste(
             "Top cutoff on x-axis for identifying variable genes",
             "See Seurat::FindVariableGenes(x.low.cutoff=...)"
+            )
+    ),
+        make_option(
+        c("--minmean"),
+        type="double",
+        default=0,
+        help=paste(
+            "minimum mean of log counts when using trendvar method"
+            )
+        ),
+        make_option(
+        c("--vargenespadjust"),
+        type="double",
+        default=0.05,
+        help=paste(
+            "significance threshold for trendvar method"
             )
         ),
     make_option(
@@ -668,17 +685,70 @@ writeTex(tex_file, tex)
 ## ######################################################################### ##
 
 ## identify variable genes and output the plots
-png(
-    file.path(opt$outdir, "varGenesPlot.png"), width=8, height=5, unit="in",
-    res=300
-    )
+
+## We need to run FindVariableGenes to set s@hvg.info
+## even if "trendvar" method is specified...
+if(opt$vargenesmethod=="trendvar")
+{
+    fvg_method="mean.var.plot"
+} else {
+    fvg_method=opt$vargenesmethod
+}
+
 s <- FindVariableGenes(
     s, mean.function=ExpMean, dispersion.function=LogVMR,
-    selection.method=opt$vargenesmethod, top.genes=opt$topgenes,
+    selection.method=fvg_method, top.genes=opt$topgenes,
     x.low.cutoff=opt$xlowcutoff, x.high.cutoff=opt$xhighcutoff,
-    y.cutoff=opt$sdcutoff, plot.both=TRUE, do.text=FALSE, do.contour=FALSE
-    )
-dev.off()
+    y.cutoff=opt$sdcutoff, do.plot=FALSE, do.text=FALSE, do.contour=FALSE
+)
+
+if(opt$vargenesmethod=="trendvar")
+{
+    message("setting variable genes using the trendvar method")
+    require(scran)
+    require(scater)
+    ss <- as.SingleCellExperiment(s)
+
+    var.fit.nospike <- trendVar(ss, parametric=TRUE,
+                                use.spikes=FALSE, loess.args=list(span=0.2))
+    var.out.nospike <- decomposeVar(ss, var.fit.nospike,
+                                    subset.row=rowMeans(as.matrix(logcounts(ss))) > opt$minmean)
+
+
+    # TODO: some plots should be made.
+    # plot(var.out.nospike$mean, var.out.nospike$total, pch=16, cex=0.6,
+    #     xlab="Mean log-expression", ylab="Variance of log-expression")
+    # curve(var.fit.nospike$trend(x), col="dodgerblue", lwd=2, add=TRUE)
+    # points(var.out.nospike$mean[cur.spike], var.out.nospike$total[cur.spike], col="red", pch=16)
+    hvg.out <- var.out.nospike[which(var.out.nospike$FDR <= opt$vargenespadjust),]
+    hvg.out <- hvg.out[order(hvg.out$bio, decreasing=TRUE),]
+
+    # overwrite the slot!
+    s@var.genes <- row.names(hvg.out)
+    #s@hvg.info <- var.out.nospike
+}
+
+
+## make a plot that shows the variable genes.
+xx <- s@hvg.info
+
+xx$var.gene = FALSE
+xx$var.gene[rownames(xx) %in% s@var.genes] <- TRUE
+
+xxm <- melt(xx, id.vars=c("var.gene","gene.mean"))
+
+gp <- ggplot(xxm, aes(gene.mean, value,color=var.gene))
+gp <- gp + scale_color_manual(values=c("black","red"))
+gp <- gp + geom_point(alpha = 1, size=0.5)
+gp <- gp + facet_wrap(~variable, scales="free")
+gp <- gp + theme_classic()
+
+save_ggplots(file.path(opt$outdir, "varGenesPlot.png"),
+             gp=gp,
+             width=8,
+             height=5)
+
+
 
 cat("no. variable genes: ", length(s@var.genes), "\n")
 stats$no_variable_genes <- length(s@var.genes)

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -25,6 +25,8 @@
   * R.utils
   * S4Vectors
   * Seurat
+  * scran
+  * scater
   * xtable
   * gsfisher (see [INSTALL](INSTALL.md))
   * tenxutils (see [INSTALL](INSTALL.md))

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -263,6 +263,8 @@ def beginSeurat(infile, outfile):
                    --sdcutoff=%(vargenes_sdcutoff)s
                    --xlowcutoff=%(vargenes_xlowcutoff)s
                    --xhighcutoff=%(vargenes_xhighcutoff)s
+                   --minmean=%(vargenes_minmean)s
+                   --vargenespadjust=%(vargenes_padjust)s
                    --jackstrawnumreplicates=%(dimreduction_jackstraw_n_replicate)s
                    --numcores=12
                    --plotdirvar=sampleDir

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -2051,6 +2051,7 @@ def latexVars(infile, outfile):
             "modelType": "%(regress_modeluse)s" % PARAMS,
             "latentVariables": "%(latentvars)s" % locals(),
             "cellCycle": "%(regress_cellcycle)s" % PARAMS,
+            "varGeneMethod": "%(vargenes_method)s" % PARAMS,
             "sdCutOff": "%(vargenes_sdcutoff)s" % PARAMS,
             "conservedFactor": "%(conservedFactor)s" % locals(),
             "conservedBetweenFactor": "%(conservedBetweenFactor)s" % locals()}

--- a/pipelines/pipeline_seurat/introReport.tex
+++ b/pipelines/pipeline_seurat/introReport.tex
@@ -15,7 +15,7 @@
 \vspace{10mm}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.6\textwidth,height=0.4\textheight,keepaspectratio]{{{\tsneDir/tsne.cluster}}}
+\includegraphics[width=0.6\textwidth,height=0.4\textheight,keepaspectratio]{{{\umapDir/umap.cluster}}}
 \end{figure}
 
 \vspace{\fill}

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -149,8 +149,10 @@ regress:
 # ---------------------------------------
 
 vargenes:
-    # Either "mean.var.plot" or "dispersion" (experimental: "trendvar")
-    method: mean.var.plot
+    # Either "mean.var.plot" or "dispersion" or "trendvar"
+    # use of trendvar is recommended and requires the
+    # bioconductor packages "scran" and "scater"
+    method: trendvar
     #
     # options for mean.var.plot method
     # --------------------------------
@@ -171,9 +173,10 @@ vargenes:
     # Implementation experimental, use at own risk!
     # threshold for identification of genes with significant biological variation
     padjust: 0.05
-    # recommeded to leave this at 0 to allow identification of weak signals
-    minmean: 0
-
+    # Minimum average expression for inclusion as a variable gene
+    # It is has been recommeded to leave this at 0 to allow identification of weak signals
+    # from rare cell types. Equivalent to "xlowcutoff" for seurat.
+    minmean: 0.01
 
 # Dimension reduction parameters
 # ------------------------------

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -149,18 +149,30 @@ regress:
 # ---------------------------------------
 
 vargenes:
-    # Either "mean.var.plot" or "dispersion"
+    # Either "mean.var.plot" or "dispersion" (experimental: "trendvar")
     method: mean.var.plot
-    # The number of top genes
-    # (for "dispersion" selection method, othewise ignored).
-    topgenes: 1000
-    ## Identification of variable genes (see Seurat::FindVariableGenes)
+    #
+    # options for mean.var.plot method
+    # --------------------------------
     # Bottom cutoff on y-axis for identifying variable genes (see y.cutoff=...)
     sdcutoff: 1
     # Bottom cutoff on x-axis for identifying variable genes (see x.low.cutoff=...)
     xlowcutoff: 0.1
     # Top cutoff on x-axis for identifying variable genes (see x.high.cutoff=...)
     xhighcutoff: 8
+    #
+    # options for dispersion method
+    # -----------------------------
+    # The number of top genes
+    topgenes: 1000
+    #
+    # options for trendvar method
+    # ---------------------------
+    # Implementation experimental, use at own risk!
+    # threshold for identification of genes with significant biological variation
+    padjust: 0.05
+    # recommeded to leave this at 0 to allow identification of weak signals
+    minmean: 0
 
 
 # Dimension reduction parameters

--- a/pipelines/pipeline_seurat/variableGeneSection.tex
+++ b/pipelines/pipeline_seurat/variableGeneSection.tex
@@ -1,6 +1,6 @@
 \subsection{Identification of variable genes}
 
-A standard deviation threshold of \sdCutOff{} was used to identifiy variable genes for PCA analysis.
+The selection method used to identifiy highly variable genes was: \varGeneMethod{}
 
 \begin{figure}[H]
 \includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\sampleDir/varGenesPlot}}}


### PR DESCRIPTION
Trendvar is a superior and statistically rigorous way to select variable genes.

If used, requires "scater" and "scran". For further information see:
https://www.bioconductor.org/packages/devel/workflows/vignettes/simpleSingleCell/inst/doc/xtra-3-var.html#2_detecting_highly_variable_genes

Additionally improve variable gene diagnostic plots to show the selected genes.