### PR TITLE
improve geneset plots

### DIFF
--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -63,6 +63,9 @@ if("gene_id" %in% colnames(s@misc))
     ## map to the seurat ids via the ensembl_ids...
     id_col = "gene_id"
     map <- data.frame(s@misc[s@misc$gene_id %in% genes$gene_id,])
+
+    #subset the map to genes with expression data.
+    map <- map[map$seurat_id %in% rownames(s@data),]
     rownames(map) <- map$gene_id
     genes <- genes[genes$gene_id %in% rownames(map),]
     genes$seurat_id <- as.vector(map[genes$gene_id,"seurat_id"])
@@ -97,6 +100,10 @@ for(group in unique(genes$group))
     rownames(tmp) <- tmp$seurat_id
 
     message("prepared the gene table for group: ", group)
+
+
+    print(rownames(tmp))
+    print(rownames(tmp)[rownames(tmp) %in% rownames(s@data)])
 
     data <- as.data.frame(as.matrix(s@data[rownames(tmp),]))
     rownames(data) <- tmp$plot_name

--- a/R/summariseGenesets.R
+++ b/R/summariseGenesets.R
@@ -47,8 +47,8 @@ option_list <- list(
                 help="expected prefix for source files"),
     make_option(c("--plotdirvar"), default="clusterGenesetsDir",
                 help="latex var containing name of the directory with the plots"),
-    make_option(c("--outfile"), default="none",
-                help="outfile")
+    make_option(c("--outprefix"), default="none",
+                help="prefix for outfiles")
     )
 
 opt <- parse_args(OptionParser(option_list=option_list))
@@ -244,7 +244,7 @@ for(geneset in genesets)
         if(nrow(results_table) > 0) { make_plot <- TRUE }
     }
 
-    plotfn <- gsub("sentinel",geneset,opt$outfile)
+    plotfn <- paste(opt$outprefix, geneset, sep=".")
     if(make_plot)
     {
 
@@ -299,9 +299,8 @@ for(geneset in genesets)
                         gp <- visualiseClusteredGenesets(tmp,
                                                          highlight=genesets_to_show[genesets_to_show %in% tmp$geneset_id] )
 
-                        detailed_plotfn <- gsub("sentinel",
-                                       paste(geneset, "circle_plot", cluster, sep="."),
-                                       opt$outfile)
+                        detailed_plotfn <- paste(opt$outprefix,
+                                                 geneset, "circle_plot", cluster, sep=".")
 
                         save_ggplots(detailed_plotfn,
                                      gp,
@@ -338,10 +337,12 @@ for(geneset in genesets)
 
 }
 
-fig_file <- gsub("sentinel","figure.tex",opt$outfile)
+fig_file <- paste(opt$outprefix,"figure.tex", sep=".")
 writeTex(fig_file,tex)
 
-saveWorkbook(wb, file=opt$outfile, overwrite=T)
+saveWorkbook(wb,
+             file=paste(opt$outprefix, "xlsx", sep="."),
+             overwrite=T)
 
 begin=T
 hlines <- c()
@@ -369,7 +370,7 @@ for(cluster in names(ltabs))
 
 }
 
-ltab_file <- gsub("sentinel","table.tex",opt$outfile)
+ltab_file <- paste(opt$outprefix,"table.tex", sep=".")
 
 if(!exists("out"))
 {

--- a/R/summariseGenesets.R
+++ b/R/summariseGenesets.R
@@ -30,10 +30,15 @@ option_list <- list(
                            "be shown in the summary heatmap")),
     make_option(c("--mingenes"), type="integer", default=2,
                 help="min no. genes in foreground set"),
-    make_option(c("--minoddsratio"), type="integer", default=1.5,
+    make_option(c("--maxgenes"), type="integer", default=500,
+                help="the maximum number of genes allowed per geneset"),
+    make_option(c("--minoddsratio"), type="double", default=1.5,
                 help="The minimum odds ratio."),
     make_option(c("--gmt_names"), default="none",
                 help="comma separated list of names for the gmt files"),
+    make_option(c("--show_detailed"), default="none",
+                help=paste("comma separated list of names for which to make individual",
+                "per-sample/cluster plots")),
     make_option(c("--clustertype"),default="cluster",
                 help="will be used e.g. in plot labels"),
     make_option(c("--project"), default="SeuratAnalysis",
@@ -62,6 +67,15 @@ if(opt$gmt_names != "none")
     gmt_names <- c()
 }
 
+if(opt$show_detailed != "none")
+{
+    show_detailed <- strsplit(opt$show_detailed,",")[[1]]
+} else {
+    show_detailed <- c()
+}
+
+
+
 ## TODO: Detect automatically
 genesets = c("GO.BP","GO.MF","GO.CC",
              "KEGG",
@@ -76,9 +90,9 @@ tex <- c()
 
 for(geneset in genesets)
 {
-    contents <- NULL
+    genesets <- NULL
 
-    print(paste("Processing:", geneset,"annotations."))
+    message(paste("Processing:", geneset,"annotations."))
     begin=T
 
     if(opt$firstcluster==0)
@@ -94,7 +108,7 @@ for(geneset in genesets)
     ## all clusters
     for(cluster in first:last)
     {
-        print(paste("Working on cluster: ", cluster))
+        message(paste("Working on cluster: ", cluster))
 
         fn = paste0(opt$genesetdir,"/",opt$prefix,".",cluster,".",geneset,".txt.gz")
         if(file.exists(fn))
@@ -106,19 +120,19 @@ for(geneset in genesets)
                     temp$cluster <- cluster
                 }
                 else {
-                    print(paste0("zero rows for cluster: ",cluster))
+                    message(paste0("zero rows for cluster: ",cluster))
                 }
 
                 if(begin==T)
                 {
-                    contents <- temp
+                    genesets <- temp
                     begin <- F
                 }
                 else {
-                    contents <- rbind(contents,temp)
+                    genesets <- rbind(genesets,temp)
                 }
             } else {
-                print(paste("Skipping ",fn,"(file not found)",sep="\t"))
+                message(paste("Skipping ",fn,"(file not found)",sep="\t"))
             }
 
     }
@@ -126,33 +140,27 @@ for(geneset in genesets)
     make_plot = FALSE
 
     ## Filter out genesets we do not wish to consider
-    contents <- contents[contents$n_fg >= opt$mingenes,]
+    filtered_genesets <- filterGenesets(genesets,
+                                   min_foreground_genes = opt$mingenes,
+                                   max_genes_geneset = opt$maxgenes,
+                                   min_odds_ratio = opt$minoddsratio,
+                                   padjust_method=opt$padjustmethod,
+                                   use_adjusted_pvalues=opt$useadjusted,
+                                   pvalue_threshold=opt$pvaluethreshold)
 
-    if(!is.null(contents) && nrow(contents) > 0)
+
+    results_table <- filtered_genesets
+
+    if(!is.null(results_table) && nrow(results_table) > 0)
     {
 
+        id_tab <- table(results_table$geneset_id)
 
-        ## Compute adjusted p-values
-        ## The input table contains _all tested genesets_
-        ## (with n_fg >= opt$mingenes) regardless of p value.
-        contents$p.adj <- p.adjust(contents$p.val, method=opt$padjustmethod)
-
-        ## Compute the number of clusters in which each geneset is signficantly enriched
-
-        if(opt$useadjusted)
-        {
-            nsigtmp <- contents[contents$p.adj < opt$pvaluethreshold,]
-        } else {
-            nsigtmp <- contents[contents$p.val < opt$pvaluethreshold,]
-        }
-
-        id_tab <- table(nsigtmp$geneset_id)
-
-        contents$n_clust_sig <- id_tab[contents$geneset_id]
-        contents$n_clust_sig[is.na(contents$n_clust_sig)] <- 0
+        results_table$n_clust_sig <- id_tab[results_table$geneset_id]
+        results_table$n_clust_sig[is.na(results_table$n_clust_sig)] <- 0
 
         ## Sort by p value
-        contents <- contents[order(contents$cluster,contents$p.val),]
+        results_table <- results_table[order(results_table$cluster,results_table$p.val),]
 
         ## Tidy up the frame
         firstcols <- c("cluster","geneset_id","description",
@@ -160,16 +168,16 @@ for(geneset in genesets)
                        "odds.ratio",
                        "n_clust_sig","n_fg","n_bg")
 
-        firstcols <- firstcols[firstcols %in% colnames(contents)]
-        othercols <- colnames(contents)[!colnames(contents) %in% firstcols]
-        contents <- contents[,c(firstcols,othercols)]
+        firstcols <- firstcols[firstcols %in% colnames(results_table)]
+        othercols <- colnames(results_table)[!colnames(results_table) %in% firstcols]
+        results_table <- results_table[,c(firstcols,othercols)]
 
-        numeric_cols <- colnames(contents)[sapply(contents, is.numeric)]
+        numeric_cols <- colnames(results_table)[sapply(results_table, is.numeric)]
 
         for(numeric_col in numeric_cols)
         {
             ## set to 3 sf
-            xx <- contents[[numeric_col]]
+            xx <- results_table[[numeric_col]]
 
             nas <- is.na(xx)
             if(any(abs(xx)==Inf))
@@ -183,21 +191,21 @@ for(geneset in genesets)
 
             xx[ints] <- as.integer(xx[ints])
 
-            contents[[numeric_col]] <- xx
+            results_table[[numeric_col]] <- xx
         }
 
         ## Add the results to the worksheet
         addWorksheet(wb,geneset)
-        setColWidths(wb,geneset,cols=1:ncol(contents),widths=10)
+        setColWidths(wb,geneset,cols=1:ncol(results_table),widths=10)
         hs <- createStyle(textDecoration = "BOLD")
-        writeData(wb, geneset, contents, withFilter = T, headerStyle=hs)
+        writeData(wb, geneset, results_table, withFilter = T, headerStyle=hs)
 
         ## prepare for writing out a latex summary table (unique pathways)
         ## and geneset heatmaps (can be shared)
-        for(clust in unique(as.character(contents$cluster)))
+        for(clust in unique(as.character(results_table$cluster)))
         {
 
-            temp <- contents[contents$cluster==clust,]
+            temp <- results_table[results_table$cluster==clust,]
             nrows <- nrow(temp)
             if(nrows==0) { next }
             temp <- temp[1:min(nrows,5),]
@@ -209,11 +217,10 @@ for(geneset in genesets)
 
             ## trim long descriptions
             maxl <- 45
-            xx <- temp$description
 
-            xx <- temp$description
-            xx <- formatDescriptions(xx, c("REACTOME_", "BIOCARTA_"), maxl)
-            temp$description <- xx
+            temp$description <- formatDescriptions(temp$description,
+                                                   c("REACTOME_", "BIOCARTA_"),
+                                                   maxl)
 
             temp_names <- colnames(temp)
             temp$type <- geneset
@@ -234,46 +241,82 @@ for(geneset in genesets)
             }
         }
 
-        results_table <- contents
-
-        ## catch case where there is nothing to plot.
-        if(opt$useadjusted)
-        {
-            nsig = nrow(results_table[results_table$p.adj < opt$pvaluethreshold &
-                                      results_table$odds.ratio >= opt$minoddsratio,])
-        } else {
-            nsig =  nrow(results_table[results_table$p.val < opt$pvaluethreshold &
-                                       results_table$odds.ratio >= opt$minoddsratio,])
-        }
-
-        if(nsig > 0) { make_plot <- TRUE }
+        if(nrow(results_table) > 0) { make_plot <- TRUE }
     }
 
-    plotfn <- gsub("xlsx",geneset,opt$outfile)
+    plotfn <- gsub("sentinel",geneset,opt$outfile)
     if(make_plot)
     {
 
-        plot_fn <- function()
+        xx <- filtered_genesets
+
+        if(!opt$showcommon)
         {
-            sampleEnrichmentHeatmap(results_table,
-                                    max_rows=50,
-                                    min_genes=opt$mingenes,
-                                    p_col="p.val",
-                                    adjust_pvalues=opt$useadjusted,
-                                    padjust_method=opt$padjustmethod,
-                                    pvalue_threshold=opt$pvaluethreshold,
-                                    min_odds_ratio=opt$minoddsratio,
-                                    maxl=45,
-                                    show_common=opt$showcommon,
-                                    sample_id_col="cluster",
-                                    sample_ids=c(first:last),
-                                    title=geneset)
+           tmp <- table(xx$geneset_id)
+           xx <- xx[!xx$geneset_id %in% names(tmp)[tmp==opt$nclusters],]
         }
 
-        save_plots(plotfn,
-                   plot_fn=plot_fn,
-                   width=8,
-                   height=8)
+        xx$score <- -log10(xx$p.adj) * log2(xx$odds.ratio)
+
+        genesets_to_show <- getSampleGenesets(xx,
+                                              sort_by = "score",
+                                              max_rows = 50)
+
+        # add back adjusted p values
+        genesets$p.adj <- NA
+        genesets[rownames(filtered_genesets),"p.adj"] <- filtered_genesets$p.adj
+
+        gp <- sampleEnrichmentDotplot(genesets,
+                                      selected_genesets = genesets_to_show,
+                                      selection_col = "geneset_id",
+                                      sample_levels =c(first:last),
+                                      min_dot_size =1, max_dot_size = 6,
+                                      maxl = 45,
+                                      pvalue_threshold = opt$pvaluethreshold,
+                                      title=geneset)
+
+
+        save_ggplots(plotfn,
+                     gp,
+                     width=8,
+                     height=8)
+
+
+        per_sample_tex = c()
+        if(geneset %in% show_detailed)
+        {
+
+                ## make the per sample plots
+                for(cluster in unique(xx$cluster))
+                {
+                    tmp <- xx[xx$cluster==cluster,]
+                    tmp <- tmp[rev(order(tmp$score)),]
+
+                    max_n_cat = 150
+
+                    if(nrow(tmp)> max_n_cat) { tmp <- tmp[1:max_n_cat,] }
+
+                        gp <- visualiseClusteredGenesets(tmp,
+                                                         highlight=genesets_to_show[genesets_to_show %in% tmp$geneset_id] )
+
+                        detailed_plotfn <- gsub("sentinel",
+                                       paste(geneset, "circle_plot", cluster, sep="."),
+                                       opt$outfile)
+
+                        save_ggplots(detailed_plotfn,
+                                     gp,
+                                     width=10, height=10)
+
+                        caption <- paste("Cluster", cluster, geneset,
+                                         "genesets clustered by similarity between over-represented genes.", sep=" ")
+
+                        per_sample_tex <- c(per_sample_tex,
+                                            getFigureTex(basename(detailed_plotfn),
+                                                         caption,
+                                                         plot_dir_var=opt$plotdirvar))
+
+                    }
+        }
 
     } else {
             # draw an empty plot with an error message
@@ -286,12 +329,16 @@ for(geneset in genesets)
 
     caption <- paste("Heatmap of the top", geneset, "genesets", sep=" ")
     tex <- c(tex,getSubsectionTex(geneset))
+
     tex <- c(tex,getFigureTex(basename(plotfn), caption,
                               plot_dir_var=opt$plotdirvar))
-    tex <- c(tex,"\n")
+
+    tex <- c(tex, "\n",
+             per_sample_tex, "\n")
+
 }
 
-fig_file <- gsub("xlsx","figure.tex",opt$outfile)
+fig_file <- gsub("sentinel","figure.tex",opt$outfile)
 writeTex(fig_file,tex)
 
 saveWorkbook(wb, file=opt$outfile, overwrite=T)
@@ -322,7 +369,7 @@ for(cluster in names(ltabs))
 
 }
 
-ltab_file <- gsub("xlsx","table.tex",opt$outfile)
+ltab_file <- gsub("sentinel","table.tex",opt$outfile)
 
 if(!exists("out"))
 {

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -1838,7 +1838,7 @@ def summariseGenesetAnalysis(infile, outfile):
 
     job_memory = "20G"
 
-    logfile = outfile + ".log"
+    logfile = outfile.replace(".sentinel", ".log")
 
     use_adjusted = str(PARAMS["genesets_use_adjusted_pvalues"]).upper()
     show_common = str(PARAMS["genesets_show_common"]).upper()
@@ -1850,13 +1850,13 @@ def summariseGenesetAnalysis(infile, outfile):
                          --gmt_names=%(gmt_names)s
                          --show_detailed=%(show_detailed)s
                          --nclusters=%(nclusters)s
-                         --mingenes=2
+                         --mingenes=%(genesets_min_fg_genes)s
                          --pvaluethreshold=%(genesets_pvalue_threshold)s
                          --padjustmethod=%(genesets_padjust_method)s
                          --useadjusted=%(use_adjusted)s
                          --minoddsratio=%(genesets_min_odds_ratio)s
                          --showcommon=%(show_common)s
-                         --outfile=%(outfile)s
+                         --outprefix=%(outdir)s/cluster.genesets
                          --prefix=genesets
                          --plotdirvar=clusterGenesetsDir
                     &> %(logfile)s
@@ -1981,7 +1981,7 @@ def summariseGenesetAnalysisBetweenConditions(infile, outfile):
 
     job_memory = "20G"
 
-    logfile = outfile + ".log"
+    logfile = outfile.replace(".sentinel", ".log")
 
     gmt_names, gmt_files = parseGMTs(param_keys=["gmt_pathway_files_"])
 
@@ -1995,12 +1995,13 @@ def summariseGenesetAnalysisBetweenConditions(infile, outfile):
                          --gmt_names=%(gmt_names)s
                          --show_detailed=%(show_detailed)s
                          --nclusters=%(nclusters)s
-                         --mingenes=2
+                         --mingenes=%(genesets_min_fg_genes)s
                          --pvaluethreshold=%(genesets_pvalue_threshold)s
                          --padjustmethod=%(genesets_padjust_method)s
+                         --minoddsratio=%(genesets_min_odds_ratio)s
                          --useadjusted=%(use_adjusted)s
                          --showcommon=%(show_common)s
-                         --outfile=%(outfile)s
+                         --outprefix=%(outdir)s/condition.genesets
                          --prefix=genesets.between
                          --plotdirvar=conditionGenesetsDir
                     &> %(logfile)s
@@ -2388,8 +2389,8 @@ def export(infile, outfile):
                os.path.join(run_dir,"latex.dir","summaryReport.pdf"),
                os.path.join(run_dir,"cluster.markers.dir","markers.summary.table.xlsx"),
                os.path.join(run_dir,"condition.markers.dir",between_xlsx),
-               os.path.join(run_dir, "cluster.genesets.dir","geneset.analysis.xlsx"),
-               os.path.join(run_dir, "condition.genesets.dir","geneset.analysis.between.xlsx")]
+               os.path.join(run_dir, "cluster.genesets.dir","cluster.genesets.xlsx"),
+               os.path.join(run_dir, "condition.genesets.dir","condition.genesets.xlsx")]
 
     for target_file in targets:
 

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -1735,7 +1735,7 @@ def parseGMTs(param_keys=["gmt_pathway_files_"]):
 @transform(findMarkers,
            regex(r"(.*)/cluster.markers.dir/.*.sentinel"),
            add_inputs(getGenesetAnnotations),
-           r"\1/cluster.genesets.dir/genesetAnalysis.sentinel")
+           r"\1/cluster.genesets.dir/geneset.analysis.sentinel")
 def genesetAnalysis(infiles, outfile):
     '''
     Naive geneset over-enrichment analysis of cluster marker genes.
@@ -1814,7 +1814,7 @@ def genesetAnalysis(infiles, outfile):
 
 @transform(genesetAnalysis,
            regex(r"(.*)/.*.sentinel"),
-           r"\1/geneset.analysis.xlsx")
+           r"\1/summarise.geneset.analysis.sentinel")
 def summariseGenesetAnalysis(infile, outfile):
     '''
     Summarise the geneset over-enrichment analyses of cluster marker genes.
@@ -1843,9 +1843,12 @@ def summariseGenesetAnalysis(infile, outfile):
     use_adjusted = str(PARAMS["genesets_use_adjusted_pvalues"]).upper()
     show_common = str(PARAMS["genesets_show_common"]).upper()
 
+    show_detailed = str(PARAMS["genesets_show_detailed"])
+
     statement = '''Rscript %(tenx_dir)s/R/summariseGenesets.R
                          --genesetdir=%(genesetdir)s
                          --gmt_names=%(gmt_names)s
+                         --show_detailed=%(show_detailed)s
                          --nclusters=%(nclusters)s
                          --mingenes=2
                          --pvaluethreshold=%(genesets_pvalue_threshold)s
@@ -1858,8 +1861,9 @@ def summariseGenesetAnalysis(infile, outfile):
                          --plotdirvar=clusterGenesetsDir
                     &> %(logfile)s
                       '''
-
     P.run(statement)
+
+    IOTools.touch_file(outfile)
 
 
 # ------------------- < within cluster geneset analysis > ------------------- #
@@ -1869,7 +1873,7 @@ def summariseGenesetAnalysis(infile, outfile):
 @transform(findMarkersBetweenConditions,
            regex(r"(.*)/condition.markers.dir/.*.sentinel"),
            add_inputs(getGenesetAnnotations),
-           r"\1/condition.genesets.dir/genesetAnalysisBetweenConditions.sentinel")
+           r"\1/condition.genesets.dir/geneset.analysis.between.conditions.sentinel")
 def genesetAnalysisBetweenConditions(infiles, outfile):
     '''
     Naive geneset over-enrichment analysis of genes DE within-cluster.
@@ -1957,7 +1961,7 @@ def genesetAnalysisBetweenConditions(infiles, outfile):
 @active_if(PARAMS["findmarkers_between"])
 @transform(genesetAnalysisBetweenConditions,
            regex(r"(.*)/.*.sentinel"),
-           r"\1/geneset.analysis.between.xlsx")
+           r"\1/summarise.geneset.analysis.between.conditions.sentinel")
 def summariseGenesetAnalysisBetweenConditions(infile, outfile):
     '''
     Summarise the geneset over-enrichment analyses of genes DE within-cluster.
@@ -1984,9 +1988,12 @@ def summariseGenesetAnalysisBetweenConditions(infile, outfile):
     use_adjusted = str(PARAMS["genesets_use_adjusted_pvalues"]).upper()
     show_common = str(PARAMS["genesets_show_common"]).upper()
 
+    show_detailed = str(PARAMS["genesets_show_detailed"])
+
     statement = '''Rscript %(tenx_dir)s/R/summariseGenesets.R
                          --genesetdir=%(genesetdir)s
                          --gmt_names=%(gmt_names)s
+                         --show_detailed=%(show_detailed)s
                          --nclusters=%(nclusters)s
                          --mingenes=2
                          --pvaluethreshold=%(genesets_pvalue_threshold)s
@@ -2001,6 +2008,7 @@ def summariseGenesetAnalysisBetweenConditions(infile, outfile):
 
     P.run(statement)
 
+    IOTools.touch_file(outfile)
 
 # ---------------------- < geneset analysis target > ---------------------- #
 
@@ -2044,7 +2052,7 @@ def plots():
          genesets,
          plots)
 @transform(summariseGenesetAnalysis,
-           regex("(.*)/cluster.genesets.dir/geneset.analysis.xlsx"),
+           regex("(.*)/cluster.genesets.dir/summarise.geneset.analysis.sentinel"),
            r"\1/latex.dir/report.vars.sty")
 def latexVars(infile, outfile):
     '''

--- a/pipelines/pipeline_seurat/genesetBetweenSection.tex
+++ b/pipelines/pipeline_seurat/genesetBetweenSection.tex
@@ -1,7 +1,7 @@
 A hypergeometric test is used to test for the enrichment of GO, KEGG and msigdb genesets amongst the positive marker genes for each cluster. The full results
 are available as a separate xlsx document.
 
-\input{\conditionGenesetsDir/geneset.analysis.between.figure.tex}
+\input{\conditionGenesetsDir/summarise.geneset.analysis.between.conditions.figure.tex}
 
 \clearpage
 
@@ -9,6 +9,6 @@ are available as a separate xlsx document.
 
 The table lists the top (filtered by nominal p value) genesets by cluster.
 
-\input{\conditionGenesetsDir/geneset.analysis.between.table.tex}
+\input{\conditionGenesetsDir/summarise.geneset.analysis.between.conditions.table.tex}
 
 \clearpage

--- a/pipelines/pipeline_seurat/genesetBetweenSection.tex
+++ b/pipelines/pipeline_seurat/genesetBetweenSection.tex
@@ -1,7 +1,7 @@
 A hypergeometric test is used to test for the enrichment of GO, KEGG and msigdb genesets amongst the positive marker genes for each cluster. The full results
 are available as a separate xlsx document.
 
-\input{\conditionGenesetsDir/summarise.geneset.analysis.between.conditions.figure.tex}
+\input{\conditionGenesetsDir/condition.genesets.figure.tex}
 
 \clearpage
 
@@ -9,6 +9,6 @@ are available as a separate xlsx document.
 
 The table lists the top (filtered by nominal p value) genesets by cluster.
 
-\input{\conditionGenesetsDir/summarise.geneset.analysis.between.conditions.table.tex}
+\input{\conditionGenesetsDir/condition.genesets.table.tex}
 
 \clearpage

--- a/pipelines/pipeline_seurat/genesetSection.tex
+++ b/pipelines/pipeline_seurat/genesetSection.tex
@@ -3,7 +3,7 @@
 A hypergeometric test is used to test for the enrichment of GO, KEGG and msigdb genesets amongst the positive marker genes for each cluster. The full results
 are available as a separate xlsx document.
 
-\input{\clusterGenesetsDir/geneset.analysis.figure.tex}
+\input{\clusterGenesetsDir/summarise.geneset.analysis.figure.tex}
 
 \clearpage
 
@@ -11,6 +11,6 @@ are available as a separate xlsx document.
 
 The table lists the top (filtered by nominal p value) genesets by cluster.
 
-\input{\clusterGenesetsDir/geneset.analysis.table.tex}
+\input{\clusterGenesetsDir/summarise.geneset.analysis.table.tex}
 
 \clearpage

--- a/pipelines/pipeline_seurat/genesetSection.tex
+++ b/pipelines/pipeline_seurat/genesetSection.tex
@@ -3,7 +3,7 @@
 A hypergeometric test is used to test for the enrichment of GO, KEGG and msigdb genesets amongst the positive marker genes for each cluster. The full results
 are available as a separate xlsx document.
 
-\input{\clusterGenesetsDir/summarise.geneset.analysis.figure.tex}
+\input{\clusterGenesetsDir/cluster.genesets.figure.tex}
 
 \clearpage
 
@@ -11,6 +11,6 @@ are available as a separate xlsx document.
 
 The table lists the top (filtered by nominal p value) genesets by cluster.
 
-\input{\clusterGenesetsDir/summarise.geneset.analysis.table.tex}
+\input{\clusterGenesetsDir/cluster.genesets.table.tex}
 
 \clearpage

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -397,6 +397,11 @@ genesets:
   # be shown in the summary heatmaps?
   show_common: True
 
+  # Make per-cluster geneset plots where genesets are
+  # clustered by over-represented genes
+  # either "none" or a comma-separated list of geneset names
+  show_detailed: GO.BP
+
 gmt_pathway_files:
 
   # Arbitrary genesets can be specified here using gmt files.

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -389,9 +389,13 @@ genesets:
   # summary heatmaps.
   pvalue_threshold: 0.05
 
-  # The minimum odds ratio to be used for producing the
-  # summary heatmaps.
+  # The minimum odds ratio to be used for inclusion in the
+  # plots
   min_odds_ratio: 1.5
+
+  # The minimum number of over-represented genes for
+  # inclusion in the plots
+  min_fg_genes: 3
 
   # Should genesets significantly enriched in all clusters
   # be shown in the summary heatmaps?


### PR DESCRIPTION
Improve geneset enrichment plots  …

- ** requires latest version of gsfisher **
- dot plots showing odds ratio and numbers of genes are now used
- genesets are ranked for visualisation in the dot plot based on
  a score computed as -log10(p.adj) * log2(odds.ratio)
- plots showing detailed views of per-cluster geneset enrichments can now be made
  (see genesets "show_detailed" parameter)