### PR TITLE
Fixes to correct assay selection

### DIFF
--- a/R/plot_group_numbers.R
+++ b/R/plot_group_numbers.R
@@ -46,6 +46,11 @@ option_list <- list(
       c("--seuratobject"),
       default="none",
       help="The seurat object (typically begin.rds)"
+    ),
+    make_option(
+      c("--seuratassay"),
+      default="RNA",
+      help="The seurat assay from which the counts will be retrieved",
       ),
     make_option(
       c("--subgroupfactor"),
@@ -180,6 +185,13 @@ for(group_var in group_vars)
 # Plot numbers of genes/cell and counts/cell ----
 
 s <- readRDS(opt$seuratobject)
+
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("plot_group_numbers.R running with default assay: ", DefaultAssay(s))
+
 cdata <- GetAssayData(object = s, slot = "counts")
 
 ngenes <- apply(cdata,2,function(x) sum(x>0))
@@ -240,3 +252,7 @@ for(group_var in group_vars)
 ## write out latex snippet
 writeTex(file.path(opt$outdir, paste("number","plots","tex", sep=".")),
          tex)
+
+message("plot_group_numbers.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/plot_rdims_gene.R
+++ b/R/plot_rdims_gene.R
@@ -64,6 +64,11 @@ option_list <- list(
       help="The seurat object (e.g. begin.rds)"
     ),
     make_option(
+      c("--seuratassay"),
+      default="RNA",
+      help="The seurat assay to pull the expression data from"
+    ),
+    make_option(
       c("--plotdirvar"),
       default="clusterMarkerTSNEPlotsDir",
       help="The name of the latex var specifying the location of the plots"
@@ -93,7 +98,13 @@ print(opt)
 ## read in the raw count matrix
 s <- readRDS(opt$seuratobject)
 
-## data <- GetAssayData(object = s, slot = counts)
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("plot_rdims_gene.R running with default assay: ", DefaultAssay(s))
+
+
 data <- GetAssayData(object = s, slot = "data")
 
 if("gene_id" %in% colnames(s@misc))
@@ -235,3 +246,7 @@ message("Completed plotting.")
 tex_file <- file.path(opt$outdir, paste("plot.rdims.genes", geneset, "tex", sep="."))
 
 writeTex(tex_file, tex)
+
+message("plot_rdims_gene.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -25,6 +25,11 @@ option_list <- list(
       help="The seurat object (e.g. begin.rds)"
     ),
     make_option(
+      c("--seuratassay"),
+      default="RNA",
+      help="The assay to set as default before GetAssayData is called"
+    ),
+    make_option(
       c("--clusterids"),
       default="none",
       help="The rdsfile containing the clusterids"
@@ -57,6 +62,12 @@ genes <- read.table(opt$genetable,
 s <- readRDS(opt$seuratobject)
 Idents(s) <- readRDS(opt$clusterids)
 
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+
+message("plot_violins.R running with default assay: ", DefaultAssay(s))
 
 if("gene_id" %in% colnames(s@misc))
 {
@@ -105,7 +116,7 @@ for(group in unique(genes$group))
     print(rownames(tmp))
     print(rownames(tmp)[rownames(tmp) %in% rownames(x = s)])
 
-    data <- as.data.frame(as.matrix(GetAssayData(object = s)[rownames(tmp),]))
+    data <- as.data.frame(as.matrix(GetAssayData(object = s, slot="data")[rownames(tmp),]))
     rownames(data) <- tmp$plot_name
 
     data$gene <- as.vector(rownames(data))
@@ -153,3 +164,7 @@ tex_file <- file.path(paste(opt$outprefix,"tex",
                             sep="."))
 
 writeTex(tex_file, tex)
+
+message("plot_violins.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/seurat_FindMarkers.R
+++ b/R/seurat_FindMarkers.R
@@ -19,6 +19,8 @@ stopifnot(
 option_list <- list(
     make_option(c("--seuratobject"), default="begin.rds",
                 help="A seurat object after PCA"),
+    make_option(c("--seuratassay"), default="RNA",
+                help="the assay to set as the default"),
     make_option(c("--clusterids"), default="none",
                 help="A list object containing the cluster identities"),
     make_option(c("--cluster"), default=1,
@@ -136,6 +138,12 @@ if(opt$conservedfactor != "none"){
         stop("Conserved factor has fewer than 2 levels")
     }
 }
+
+
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("seurat_FindMarkers.R running with default assay: ", DefaultAssay(s))
 
 markers.conserved.list <- list()
 background.conserved.list <- list()
@@ -572,4 +580,6 @@ if (length(markers.conserved.list) > 1){
                 quote=FALSE, sep="\t", row.names=FALSE)
 }
 
-message("Done")
+message("seurat_FindMarkers.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/seurat_characteriseClusterDEGenes.R
+++ b/R/seurat_characteriseClusterDEGenes.R
@@ -33,6 +33,8 @@ option_list <- list(
                 help="Summary table of differentially expressed genes"),
     make_option(c("--seuratobject"), default="begin.Robj",
                 help="seurat object"),
+    make_option(c("--seuratassay"), default="RNA",
+                help="the assay to set as default (used for the violin plots)"),
     make_option(c("--clusterids"), default="begin.Robj",
                 help="clusterids"),
     make_option(c("--cluster"), default="none",
@@ -83,9 +85,16 @@ tex = ""
 degenes <- read.table(gzfile(opt$degenes),header=T,as.is=T,sep="\t")
 
 ## read in the seurat object
-seurat_object <- readRDS(opt$seuratobject)
+s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
-Idents(seurat_object) <- cluster_ids
+Idents(s) <- cluster_ids
+
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("seurat_characteriseClusterDEGenes.R running with default assay: ", DefaultAssay(s))
+
 
 cluster <- opt$cluster
 
@@ -190,7 +199,7 @@ if(is.null(opt$testfactor))
 
 ## make the +ve plots
 message("making violin plots for +ve genes")
-pos_tex <- violinPlotSection(violin_data, seurat_object, cluster_ids, type="positive",
+pos_tex <- violinPlotSection(violin_data, s, cluster_ids, type="positive",
                              group.by = opt$testfactor,
                              ident.include = ident.include, ncol=ncol,
                              outdir = opt$outdir,
@@ -200,7 +209,7 @@ pos_tex <- violinPlotSection(violin_data, seurat_object, cluster_ids, type="posi
 
 ## make the -ve plots
 message("making violin plots for -ve genes")
-neg_tex <- violinPlotSection(violin_data, seurat_object, cluster_ids, type="negative",
+neg_tex <- violinPlotSection(violin_data, s, cluster_ids, type="negative",
                              group.by = opt$testfactor,
                              ident.include = ident.include, ncol=ncol,
                              outdir = opt$outdir,
@@ -216,3 +225,7 @@ tex_file <- file.path(opt$outdir,
 writeTex(tex_file, tex)
 
 }
+
+message("seurat_characteriseClusterDEGenes.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -45,6 +45,8 @@ run_specs <- paste(opt$components,opt$resolution,opt$algorithm,opt$testuse,sep="
 message(sprintf("readRDS: %s", opt$seuratobject))
 s <- readRDS(opt$seuratobject)
 
+message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
+
 ## The FindClusters() function implements the procedure, and contains a
 ## resolution parameter that sets the 'granularity' of the downstream clustering,
 ## with increased values leading to a greater number of clusters.
@@ -155,5 +157,6 @@ print(
     file=file.path(opt$outdir, "cluster.pairwise.correlations.tex")
     )
 
+message("seurat_cluster.R final default assay: ", DefaultAssay(s))
 
 message("Completed")

--- a/R/seurat_clustree.R
+++ b/R/seurat_clustree.R
@@ -16,8 +16,6 @@ stopifnot(
 # Options ----
 
 option_list <- list(
-    make_option(c("--seuratobject"), default="begin.Robj",
-                help="A seurat object after PCA"),
     make_option(c("--resolutions"), default=NULL,
                 help="a comma separated list of the cluster resolutions"),
     make_option(c("--clusteridfiles"), default=NULL,

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -54,6 +54,8 @@ s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 
+message("seurat_dm.R running with default assay: ", DefaultAssay(s))
+
 ## run the diffusion map algorithm
 if(opt$usegenes)
 {
@@ -164,6 +166,6 @@ tex_file <- file.path(opt$outdir,
 writeTex(tex_file, tex)
 
 
-
+message("seurat_dm.R final default assay: ", DefaultAssay(s))
 
 message("Completed")

--- a/R/seurat_summariseMarkersBetween.R
+++ b/R/seurat_summariseMarkersBetween.R
@@ -23,6 +23,8 @@ stopifnot(
 option_list <- list(
     make_option(c("--seuratobject"), default="begin.Robj",
                 help="A seurat object after PCA"),
+    make_option(c("--seuratassay"), default="RNA",
+                help="the seurat assay to use"),
     make_option(c("--clusterids"), default="none",
                 help="A list object containing the cluster identities"),
     make_option(c("--testfactor"),default="factor",
@@ -47,6 +49,12 @@ run_specs <- paste(opt$numpcs,opt$resolution,opt$algorithm,opt$testuse,sep="_")
 
 s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
+
+message("Setting the default seurat assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("seurat_summariseMarkersBetween.R running with default assay: ", DefaultAssay(s))
+
 
 ## cluster_ids
 clusters <- sort(unique(as.vector(cluster_ids)))
@@ -96,8 +104,8 @@ for(cluster in clusters)
            de <- read.table(gzfile(res_fn), header=T, sep="\t", as.is=T)
            de <- de[order(de$p_va),]
 
-           ameans <- rowMeans(GetAssayData(object = s, slot = "scale.data")[de$gene,as])
-           bmeans <- rowMeans(GetAssayData(object = s, slot = "scale.data")[de$gene,bs])
+           ameans <- rowMeans(GetAssayData(object = s, slot="data")[de$gene,as])
+           bmeans <- rowMeans(GetAssayData(object = s, slot="data")[de$gene,bs])
 
            de[[aName]] <- ameans
            de[[bName]] <- bmeans
@@ -247,3 +255,7 @@ save_plots(plotfn,
            plot_fn=plot_fn,
            width=6,
            height=8)
+
+message("seurat_summariseMarkersBetween.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/seurat_tsne.R
+++ b/R/seurat_tsne.R
@@ -51,6 +51,8 @@ cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 print(head(Idents(s)))
 
+message("seurat_tsne.R running with default assay: ", DefaultAssay(s))
+
 ## check that the perplexity value specified is sensible
 ncells <- ncol(GetAssayData(object = s))
 message("no. cells:", ncells)
@@ -98,3 +100,5 @@ if(opt$perplexity > floor(ncells/5))
 message("Completed")
 
     }
+
+message("seurat_tsne.R final default assay: ", DefaultAssay(s))

--- a/R/seurat_umap.R
+++ b/R/seurat_umap.R
@@ -50,6 +50,8 @@ s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 
+message("seurat_umap.R running with default assay: ", DefaultAssay(s))
+
 ## get the principle components to use
 if(opt$usesigcomponents)
 {
@@ -63,11 +65,8 @@ if(opt$usesigcomponents)
 ## run UMAP
 message("RunUMAP")
 s <- RunUMAP(s,
-             # cells.use = NULL,
              reduction = opt$reductiontype,
              dims = comps,
-             # genes.use = NULL,
-             assay = "RNA",
              n.components = 2L,
              reduction.name = "umap",
              reduction.key = "UMAP",
@@ -90,5 +89,7 @@ plot_data$barcode <- row.names(plot_data)
 ## save the annotated tSNE data frame
 write.table(plot_data, opt$outfile,
             sep="\t", quote=FALSE, row.names=FALSE)
+
+message("seurat_umap.R final default assay: ", DefaultAssay(s))
 
 message("Completed")

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -102,6 +102,12 @@ wildtype.seurat.dir/begin.rds
 knockout.seurat.dir/begin.rds
 aggregated.seurat.dir/begin.rds
 
+The supplied object must contain an RNA assay with populated "data" and "scale.data" slots for all genes (i.e. you need to run NormlizeData and ScaleData on the RNA assay).
+
+The seurat "JackStraw" and "ScoreJackStraw" functions must have run on the reduced dimensions (e.g. pca) of the default assay of the saved object.
+
+The default assay of the saved object will be used for cell-level analyses such as cluster discovery, computation of tSNE/umap coordinates and pseudotime. Hence, if, for example, integration has been performed, "integrated" should be set as the default assay. For gene level analyses the pipeline will always use the RNA assay regardless of the default assay.
+
 (Optional - velocity) Starting from aggregated dropEst output matrix.
 
 Typically involves linking "dropEst-datasets.dir" subfolders from the
@@ -732,6 +738,7 @@ def knownMarkerViolins(infile, outfile):
     statement = '''Rscript %(tenx_dir)s/R/plot_violins.R
                        --genetable=%(knownmarkers_file)s
                        --seuratobject=%(seurat_object)s
+                       --seuratassay=RNA
                        --clusterids=%(cluster_ids)s
                        --outprefix=%(outprefix)s
                        --plotdirvar=knownmarkersDir
@@ -961,6 +968,7 @@ def plotRdimsGenes(infile, outfile):
                            --method=%(rdims_vis_method)s
                            --table=%(rdims_table)s
                            --seuratobject=%(seurat_object)s
+                           --seuratassay=RNA
                            --rdim1=%(rdim1)s
                            --rdim2=%(rdim2)s
                            %(shape)s
@@ -1054,6 +1062,7 @@ def plotGroupNumbers(infile, outfile):
     statement = '''Rscript %(tenx_dir)s/R/plot_group_numbers.R
                    --table=%(rdims_table)s
                    --seuratobject=%(seurat_object)s
+                   --seuratassay=RNA
                     %(groupfactors)s
                     %(subgroupfactor)s
                    --outdir=%(outdir)s
@@ -1158,6 +1167,7 @@ def findMarkers(infile, outfile):
         logfile = outfile.replace(".sentinel", "." + str(i) + ".log")
         statements.append('''Rscript %(tenx_dir)s/R/seurat_FindMarkers.R
                    --seuratobject=%(seurat_object)s
+                   --seuratassay=RNA
                    --clusterids=%(cluster_ids)s
                    --cluster=%(i)s
                    --testuse=%(test)s
@@ -1205,9 +1215,11 @@ def summariseMarkers(infile, outfile):
 
     log_file = outfile.replace(".sentinel", ".log")
 
+
     # make sumamary tables and plots of the differentially expressed genes
     statement = '''Rscript %(tenx_dir)s/R/seurat_summariseMarkers.R
                    --seuratobject=%(seurat_object)s
+                   --seuratassay=RNA
                    --clusterids=%(cluster_ids)s
                    %(subgroup)s
                    --outdir=%(outdir)s
@@ -1265,6 +1277,7 @@ def characteriseClusterMarkers(infile, outfile):
                     Rscript %(tenx_dir)s/R/seurat_characteriseClusterDEGenes.R
                     --degenes=%(marker_table)s
                     --seuratobject=%(seurat_object)s
+                    --seuratassay=RNA
                     --clusterids=%(cluster_ids)s
                     --cluster=%(i)s
                     --outdir=%(outdir)s
@@ -1435,6 +1448,7 @@ def plotRdimsMarkers(infile, outfile):
                            --method=%(rdims_vis_method)s
                            --table=%(rdims_table)s
                            --seuratobject=%(seurat_object)s
+                           --seuratassay=RNA
                            --rdim1=%(rdim1)s
                            --rdim2=%(rdim2)s
                            %(shape)s
@@ -1488,7 +1502,7 @@ def plotRdimsMarkers(infile, outfile):
 @active_if(PARAMS["findmarkers_between"])
 @follows(getGenesetAnnotations)
 @transform(cluster,
-           regex(r"(all.*|agg.*|aligned.*)/cluster.dir/cluster.sentinel"),
+           regex(r"(all.*|agg.*|aligned.*|integrated.*)/cluster.dir/cluster.sentinel"),
            r"\1/condition.markers.dir/findMarkersBetweenConditions.sentinel")
 def findMarkersBetweenConditions(infile, outfile):
     '''
@@ -1540,6 +1554,7 @@ def findMarkersBetweenConditions(infile, outfile):
         logfile = outfile.replace(".sentinel", "." + str(i) + ".log")
         statements.append('''Rscript %(tenx_dir)s/R/seurat_FindMarkers.R
                    --seuratobject=%(seurat_object)s
+                   --seuratassay=RNA
                    --clusterids=%(cluster_ids)s
                    --cluster=%(i)s
                    --testfactor=%(testfactor)s
@@ -1591,6 +1606,7 @@ def summariseMarkersBetweenConditions(infile, outfile):
     # make sumamary tables and plots of the differentially expressed genes
     statement = '''Rscript %(tenx_dir)s/R/seurat_summariseMarkersBetween.R
                    --seuratobject=%(seurat_object)s
+                   --seuratassay=RNA
                    --testfactor=%(findmarkers_between_testfactor)s
                    --a=%(findmarkers_between_a)s
                    --b=%(findmarkers_between_b)s
@@ -1653,6 +1669,7 @@ def characteriseClusterMarkersBetweenConditions(infile, outfile):
                     Rscript %(tenx_dir)s/R/seurat_characteriseClusterDEGenes.R
                     --degenes=%(marker_table)s
                     --seuratobject=%(seurat_object)s
+                    --seuratassay=RNA
                     --clusterids=%(cluster_ids)s
                     --cluster=%(i)s
                     --testfactor=%(testfactor)s

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -38,7 +38,7 @@ annotation:
     # When set to "default" the default host of the biomaRt package will be used.
     # The default biomaRt host is currently "www.ensembl.org".
     # If the default host is down try e.g. "uswest.ensembl.org" or "useast.ensembl.org"
-    enseml_host: default
+    ensembl_host: default
 
 # Pre-run subsetting (optional)
 # -----------------------------
@@ -218,6 +218,7 @@ dimreduction:
     # Projection method used for visualisation (umap is recommended)
     # Choices: 'umap'|'tsne'
     visualisation: umap
+
 
 # Plotting parameters
 # -------------------


### PR DESCRIPTION
Fix pipeline_seurat.py to follow the current advice of the Seurat authors (https://github.com/satijalab/seurat/issues/1717):

> "To keep this simple: You should use the integrated assay when trying to 'align' cell states that are shared across datasets (i.e. for clustering, visualization, learning pseudotime, etc.)

> You should use the RNA assay when exploring the genes that change either across clusters, trajectories, or conditions."

For sctransform the authors also currently recommend to use the RNA assay for DE analysis (https://github.com/satijalab/seurat/issues/1421). If DE analysis is instead performed on the SCT assay, the scale.data slot should then be used and this causes issues with log fold change estimates (https://github.com/satijalab/seurat/issues/1767). For DE analysis, the results from SCT and RNA "should be extremely similar" (https://github.com/satijalab/seurat/issues/1501). Until updated vignettes are available we will therefore use the RNA assay for gene-level analyses following SCT transform. When the normalisation is set to "sctransform"  the RNA assay is now log-normalised and scaled before sctransform is applied.

In short, given the above advice the pipeline has now been updated to set the RNA assay as the default slot for all gene-level (e.g. differential expression, visualisation of expression levels and pathway analysis). For cell-level analyses (e.g. clustering, visualisation, learning pseudotime), the pipeline uses the default assay (this means "RNA" if log-normalization is specified, "SCT" if sctransform is specified, or if the pipeline is started from a saved object whatever the default was set to by the user [for integrated objects, the default assay should be set to "integrated"].)


**The assays used by the pipelined R scripts have been modified as follows:**

(1) seurat_begin.py: if "log-normalization" is selected the saved object will have the "RNA" slot set as the default. If "sctransform" normalisation is selected the saved object will have both "RNA" and "SCT" slots with the "SCT" slot set as the default. [script changed so that the RNA assay is always log-normalized and scaled. The same variables are always regressed for the "RNA" and "SCT" assays.].

(2) seurat_cluster.py: this script uses the default assay (i.e. "RNA", "SCT" or "integrated") [no change].

(3) seurat_clustree.R: this script does not use the seurat object (n/a).

(4) seurat_tsne.R: the script uses the default assay. [no changes]

(5) seurat_umap.R: this script now uses the default assay. [fixed: previously the script always used the RNA assay]

(6) plot_tsne_hyperparameters.R: n/a

(7) seurat_dm.R: If run with --usegenes the script uses the "scale.data" slot from the default assay. Otherwise the script uses the --components from the default assay. [unchanged]

(8) plot_violins.R: the script now uses the RNA assay ("data" slot). [fixed, was using the default assay].

(9) plot_velocity.R: n/a

(10) plot_rdims_factor.R: n/a

(11) plot_rdims_gene.R: the script now uses the RNA assay ("data" slot) [fixed, was using the default assay]

(12) plot_group_numbers.R: the script now uses the RNA assay ("counts" slot) [fixed, was using the default assay]

(13) fetch_geneset_annotations.R: n/a

(14) seurat_FindMarkers.R: the script now uses the RNA assay in all cases. [fixed, was using the default assay]

(15) seurat_summariseMarkers.R:  the script now uses the RNA assay in all cases. [fixed, was using the default assay]

(16) seurat_characteriseClusterDEGenes.R: the script now uses the RNA assay in all cases. [fixed was using the default assay]

(17) seurat_summariseMarkerNumbers.R: n/a

(18) seurat_summariseMarkersBetween.R: script now uses the RNA assay in all cases. The "data" slot is now used for computation of mean expression levels. [fixed (i) was using the default assay, (ii) was incorrectly using the "scale.data" slot for computation of mean expression levels]

(19) genesetAnalysis.R, summariseGenesets.R: n/a

(20) aggregate_umis_psudobulks.R: n/a (this script operates on the input matrix rather than the seurat object)

**Checking assay use in pipeline_seurat.py**

Where applicable, the scripts now report the default assay that they are running with. The default assay is also reported immediately prior to script completion so that it can be verified that it has not been inadvertently changed while the script is running.

To check the assays that have been used by the scripts use a command such as:
find . -name "*.log" | xargs -I {} grep "default assay" {} | sort -u

**Notes for running pipeline_seurat.py from a saved (e.g. integrated) object**

- The supplied object must contain an RNA assay with populated "data" and "scale.data" slots for all genes (i.e. you need to have run NormlizeData and ScaleData on the RNA assay).

- The seurat "JackStraw" and "ScoreJackStraw" functions must have been run on the reduced dimensions (e.g. pca) of the default assay of the saved object.