### PR TITLE
tenxutils: Fixed usage of seurat object within function getSigPC

### DIFF
--- a/tenxutils/R/Helper.R
+++ b/tenxutils/R/Helper.R
@@ -112,7 +112,7 @@ getSigPC <- function(seurat_oject=NULL,
                      p_threshold=0.05,
                      order_by_sig=FALSE)
 {
-    x <- as.data.frame(s@reductions$pca@jackstraw@overall.p.values)
+    x <- as.data.frame(seurat_object@reductions$pca@jackstraw@overall.p.values)
 
     ## adjust the p values
     if(adjust_p)

--- a/tenxutils/R/Helper.R
+++ b/tenxutils/R/Helper.R
@@ -105,7 +105,7 @@ categoriseGenes <- function(data,m_col="avg_logFC", use_fc=TRUE,
 #' @param p_threshold The significance threshold
 #' @param order_by_sig If true, PCs are selected based on significance
 #' @param seurat_object A seurat object on which JackStraw and JackStrawPlot have been run
-getSigPC <- function(seurat_oject=NULL,
+getSigPC <- function(seurat_object=NULL,
                      ncomp=Inf,
                      adjust_p=TRUE,
                      p_adjust_method="BH",


### PR DESCRIPTION
(tenxutils): Option 'seurat_object' in function getSigPC was not used within function (called s instead)