### PR TITLE
Kj fix reduction option for find neighbors

### DIFF
--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -88,7 +88,7 @@ if(is.null(opt$predefined))
 
     message(sprintf("FindClusters"))
     s <- FindNeighbors(s,
-                       reduction.type = "pca",
+                       reduction = "pca",
                        dims = comps)
 
 

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -418,8 +418,8 @@ genesets:
   # Marker adjusted p-value threshold for it to be included in the geneset analysis (genesetAnalysis.R)
   # This value will also be used in the geneset analysis for within cluster DE
   marker_adjpthreshold: 0.1
-  
-    # A method recognised by the R "p.adjust" function
+
+  # A method recognised by the R "p.adjust" function
   # The adjustment is applied to the combined results from
   # all of the clusters.
   padjust_method: BH

--- a/tenxutils/R/Helper.R
+++ b/tenxutils/R/Helper.R
@@ -105,7 +105,7 @@ categoriseGenes <- function(data,m_col="avg_logFC", use_fc=TRUE,
 #' @param p_threshold The significance threshold
 #' @param order_by_sig If true, PCs are selected based on significance
 #' @param seurat_object A seurat object on which JackStraw and JackStrawPlot have been run
-getSigPC <- function(seurat_object=NULL,
+getSigPC <- function(seurat_oject=NULL,
                      ncomp=Inf,
                      adjust_p=TRUE,
                      p_adjust_method="BH",

--- a/tenxutils/R/Helper.R
+++ b/tenxutils/R/Helper.R
@@ -105,7 +105,7 @@ categoriseGenes <- function(data,m_col="avg_logFC", use_fc=TRUE,
 #' @param p_threshold The significance threshold
 #' @param order_by_sig If true, PCs are selected based on significance
 #' @param seurat_object A seurat object on which JackStraw and JackStrawPlot have been run
-getSigPC <- function(seurat_oject=NULL,
+getSigPC <- function(seurat_object=NULL,
                      ncomp=Inf,
                      adjust_p=TRUE,
                      p_adjust_method="BH",


### PR DESCRIPTION
FindNeighbors in Seurat was not picking up the reduced dimension from pipeline.yml as the option had the incorrect name. Therefore FindNeighbors was always running on the default 'pca' slot. Now updated to using the correct option name, so the dimension reduction can be changed.