### PR TITLE
pca was hard-coded as dimension reduction 

### DIFF
--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -88,7 +88,7 @@ if(is.null(opt$predefined))
 
     message(sprintf("FindClusters"))
     s <- FindNeighbors(s,
-                       reduction = "pca",
+                       reduction = opt$reductiontype,
                        dims = comps)
 
 

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -77,7 +77,7 @@ diff.data <- t(GetAssayData(s, slot = "scale.data")[VariableFeatures(s),])
 
     message("Running diffussion with reduced dimensions")
 
-    diff.data <- Embeddings(s, reduction="pca")[,comps]
+    diff.data <- Embeddings(s, reduction=opt$reductiontype)[,comps]
 }
 
 message("making the diffusion map")


### PR DESCRIPTION
for diffusion map and findNeighbors functions.
Tested on integrated dataset from my pipeline, where a different reduction dimension slot is required.