### PR TITLE
add_maxcount_to_cell_qc

### DIFF
--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -117,6 +117,12 @@ option_list <- list(
             )
         ),
     make_option(
+      c("--qcmaxcount"),
+      type="integer",
+      default=NULL,
+      help="Max nCount_RNA to retain a cell"
+      ),
+    make_option(
         c("--normalizationmethod"),
         default="log-normalization",
         help="The normlization method to use"
@@ -556,9 +562,17 @@ stats$qc_min_gene_threshold <- opt$qcmingenes
 stats$qc_min_percent_mito_threshold <- opt$qcminpercentmito
 stats$qc_max_percent_mito_threshold <- opt$qcmaxpercentmito
 
-s <- subset(s, subset = nFeature_RNA > opt$qcmingenes &
+if (! is.null(opt$qcmaxcount)) {
+  s <- subset(s, subset = nFeature_RNA > opt$qcmingenes &
                    percent.mito > opt$qcminpercentmito &
-                   percent.mito < opt$qcmaxpercentmito)
+                   percent.mito < opt$qcmaxpercentmito &
+                   nCount_RNA < opt$qcmaxcount)
+  stats$qc_max_count_threshold <- opt$qcmaxcount
+  } else {
+    s <- subset(s, subset = nFeature_RNA > opt$qcmingenes &
+                     percent.mito > opt$qcminpercentmito &
+                     percent.mito < opt$qcmaxpercentmito)
+    }
 
 
 stats$no_cells_after_qc <- ncol(GetAssayData(object = s))

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -277,6 +277,12 @@ def beginSeurat(infile, outfile):
     # Turn Python boolean into R logical
     downsamplecells = str(PARAMS["qc_downsamplecells"]).upper()
 
+    # Deal with maxcount option
+    if PARAMS["qc_maxcount"] != "none":
+        maxcount = '''--qcmaxcount=%(qc_maxcount)s''' % PARAMS
+    else:
+        maxcount = ""
+
     statement = '''Rscript %(tenx_dir)s/R/seurat_begin.R
                    --tenxdir=%(infile)s
                    --project=%(sample_name)s
@@ -307,6 +313,7 @@ def beginSeurat(infile, outfile):
                    %(seed)s
                    %(cell_cycle_genes)s
                    %(cell_cycle_regress)s
+                   %(maxcount)s
                    &> %(log_file)s
                 '''
 

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -135,6 +135,9 @@ qc:
     # Retain cells where at most this proportion of UMI are assigned to mitochondrial genes
     # Note that the default 5% (0.05) can be excessively stringent in some cases
     maxpercentmito: 0.05
+    # Retain cells that have less than the given UMI maximum count. This would remove very large
+    # cells with an unusually high UMI count. This threshold is not active by default
+    maxcount: none
     # Whether to downsample to a common number of cells
     # Choices: False|True
     downsamplecells: False


### PR DESCRIPTION
I have added an option in seurat_begin.r to remove cells with unusually high UMI count. pipeline_seurat.py and pipeline.yml were modified accordingly. 