### PR TITLE
tsne_and_leiden_fixes

### DIFF
--- a/R/plot_tsne_hyperparameters.R
+++ b/R/plot_tsne_hyperparameters.R
@@ -80,6 +80,10 @@ tex = ""
 print("Making tSNE plots for the grouping variables")
 
 color_var <- opt$colorfactor
+plot_data[,color_var] <- factor(plot_data[,color_var], 
+				levels=sort(as.numeric(unique(plot_data[,color_var]))))
+
+
 print(paste("Making",color_var,"tSNE plot"))
 
 ## convert the hyperparameter into a factor with correct
@@ -90,8 +94,6 @@ param_levels <- sort(unique(param_values))
 param_factor <- factor(as.character(param_values),levels=as.character(param_levels))
 
 plot_data[[opt$hyperparameter]]  <- param_factor
-
-plot_data[[color_var]] <- as.character(plot_data[[color_var]])
 
 if(opt$shapefactor=="none" | !(opt$shapefactor %in% colnames(plot_data)))
     {

--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -120,10 +120,11 @@ if(is.null(opt$predefined))
 
 
 
-nclusters <- length(unique(cluster_ids))
+nclusters <- sort(unique(cluster_ids))
 
 message(sprintf("write"))
-write(nclusters, file=file.path(opt$outdir,"nclusters.txt"))
+write.table(nclusters, file=file.path(opt$outdir,"nclusters.txt"), 
+            quote=FALSE, col.names = FALSE, row.names = FALSE)
 message(sprintf("saveRDS"))
 saveRDS(cluster_ids, file=file.path(opt$outdir,"cluster_ids.rds"))
 

--- a/R/summariseGenesets.R
+++ b/R/summariseGenesets.R
@@ -334,7 +334,8 @@ for(geneset in genesets)
 
     } else {
             # draw an empty plot with an error message
-            pngfn <- paste(plotfn, "png", sep=".")
+            per_sample_tex = c()
+	    pngfn <- paste(plotfn, "png", sep=".")
             png(pngfn,width=8,height=8,units="in",res=100)
             plot.new()
             text(0.5,0.5,paste0("no significant genesets for:\n",geneset))

--- a/tenxutils/R/Plot.R
+++ b/tenxutils/R/Plot.R
@@ -578,7 +578,7 @@ markerComplexHeatmap <- function(seurat_object,
   # set up the cluster color palette
   nclust <- length(unique(clusters))
   cluster_cols <- gg_color_hue(nclust)
-  names(cluster_cols) <- 0:(nclust-1)
+  names(cluster_cols) <- sort(as.numeric(as.character(unique(clusters))))
 
   # get the vector of per-cell cluster names
   cell_clusters <- clusters[colnames(x)]


### PR DESCRIPTION
The file nclusters.txt which is created in seurat_cluster.R used to contain a single value corresponding the to the resulting number of cluster. With the changes commited, now it consists of the actual cluster ids. The script pipeline_seurat.py was changed accordingly. This was necessary to correctly work with leiden clusters, which start with "1" instead of "0". 

The order of clusters for the tSNE plot were fixed so that the assigned colors correspond to the rest of the report.

