### PR TITLE
Sns fix cellcycle pca

### DIFF
--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -127,9 +127,10 @@ for(group in unique(genes$group))
 
     message("prepared the expression data")
 
-    nclust <- length(unique(Idents(s)))
-    colors <- gg_color_hue(nclust)
-    names(colors) <- 0:(nclust-1)
+    cluster_uids <- unique(Idents(s))
+
+    colors <- gg_color_hue(length(cluster_uids))
+    names(colors) <- cluster_uids[order(as.numeric(cluster_uids))]
 
     ncol <- 10
 

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -827,7 +827,7 @@ if (!(is.null(opt$sgenes) | opt$sgenes=="none")
                           set.ident=TRUE)
 
     s <- RunPCA(object = s,
-                pc.genes = c(sgenes, g2mgenes),
+                features = c(sgenes, g2mgenes),
                 do.print = FALSE)
 
   ## PCA plot on cell cycle genes without regression
@@ -901,7 +901,7 @@ if ( identical(opt$cellcycle, "none") ) {
     }
 
     ## visualise the cells by PCA of cell cycle genes after regression
-    s <- RunPCA(object = s, pc.genes = c(sgenes, g2mgenes), do.print = FALSE)
+    s <- RunPCA(object = s, features = c(sgenes, g2mgenes), do.print = FALSE)
     gp <- PCAPlot(object = s)
 
     cc_plot_fn <- paste("cellcycle.regressed", opt$cellcycle, "pca", sep=".")
@@ -931,7 +931,7 @@ writeTex(tex_file, tex)
 
 # perform PCA using the variable genes
 s <- RunPCA(s,
-            pc.genes=VariableFeatures(object = s),
+            features=VariableFeatures(object = s),
             npcs=100,
             do.print=FALSE)
 

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -520,6 +520,7 @@ gp <- VlnPlot(s,
               # size.title.use=14,
               # size.x.use=12,
               group.by=opt$groupby,
+              pt.size = 0.1,
               # x.lab.rot=TRUE,
               # point.size.use=0.1,
               ncol=3

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -520,7 +520,7 @@ gp <- VlnPlot(s,
               # size.title.use=14,
               # size.x.use=12,
               group.by=opt$groupby,
-              pt.size = 0.1,
+              pt.size = 0,
               # x.lab.rot=TRUE,
               # point.size.use=0.1,
               ncol=3

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -96,17 +96,15 @@ print(head(dm_coord))
 print(dim(dm_coord))
 print(head(Idents(s)))
 
+rownames(dm_coord) <- Cells(s)
 dm_coord$cluster <- Idents(s)
 
 dm_coord <- merge(dm_coord, s[[]], by=0)
 
-rownames(dm_coord) <- dm_coord$Row.names
-dm_coord$Row.names <- NULL
-
 dm_coord$barcode <- row.names(dm_coord)
 
 ## save the annotated coordinates
-write.table(dm_coord, opt$outfile,
+write.table(dm_coord, gzfile(opt$outfile),
             sep="\t", quote=FALSE, row.names=FALSE)
 
 

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -520,12 +520,12 @@ def pagaPrepareInput(infile, outfile):
     outdir = os.path.dirname(outfile)
     log_file = outfile.replace("sentinel","log")
     reductiontype = PARAMS["dimreduction_method"]
-    
-    if bool(re.search("sig", PARAMS["runspecs_n_components"])) : 
+
+    if bool(re.search("sig", PARAMS["runspecs_n_components"])) :
         comp="--usesigcomponents=TRUE"
     else :
         comp="--usesigcomponents=FALSE"
-    
+
     statement = '''Rscript %(tenx_dir)s/R/paga_prepare_input.R
                    --seuratobject=%(seurat_obj)s
                    --reductiontype=%(reductiontype)s
@@ -537,7 +537,7 @@ def pagaPrepareInput(infile, outfile):
     P.run(statement)
 
     IOTools.touch_file(outfile)
-    
+
 
 @active_if(PARAMS["paga_run"])
 @follows(pagaPrepareInput)
@@ -825,7 +825,7 @@ def diffusionMap(infile, outfile):
 
     diffmap_maxdim = PARAMS["diffusionmap_maxdim"]
 
-    outname = outfile.replace(".sentinel", ".txt")
+    outname = outfile.replace(".sentinel", ".txt.gz")
     logfile = outname.replace(".txt", ".log")
 
     statement = '''Rscript %(tenx_dir)s/R/seurat_dm.R
@@ -1323,6 +1323,7 @@ def plotGroupNumbers(infile, outfile):
 #   is not set
 # - translating ensembl gene_ids to entrez gene_ids for the geneset
 #   analysis
+
 
 @follows(mkdir("annotation.dir"))
 @files(None, "annotation.dir/genesets.sentinel")
@@ -2025,6 +2026,7 @@ def parseGMTs(param_keys=["gmt_pathway_files_"]):
 
 # ------------------- < between cluster geneset analysis > ------------------ #
 
+@active_if(PARAMS["genesets_active"])
 @follows(summariseMarkers)
 @transform(findMarkers,
            regex(r"(.*)/cluster.markers.dir/.*.sentinel"),
@@ -2109,7 +2111,7 @@ def genesetAnalysis(infiles, outfile):
 
     IOTools.touch_file(outfile)
 
-
+@active_if(PARAMS["genesets_active"])
 @transform(genesetAnalysis,
            regex(r"(.*)/.*.sentinel"),
            r"\1/summarise.geneset.analysis.sentinel")
@@ -2172,6 +2174,7 @@ def summariseGenesetAnalysis(infile, outfile):
 
 # ------------------- < within cluster geneset analysis > ------------------- #
 
+@active_if(PARAMS["genesets_active"])
 @active_if(PARAMS["findmarkers_between"])
 @follows(summariseMarkersBetweenConditions)
 @transform(findMarkersBetweenConditions,
@@ -2264,7 +2267,7 @@ def genesetAnalysisBetweenConditions(infiles, outfile):
 
     IOTools.touch_file(outfile)
 
-
+@active_if(PARAMS["genesets_active"])
 @active_if(PARAMS["findmarkers_between"])
 @transform(genesetAnalysisBetweenConditions,
            regex(r"(.*)/.*.sentinel"),
@@ -2365,9 +2368,10 @@ def plots():
 
 @follows(markers,
          genesets,
-         plots)
-@transform(summariseGenesetAnalysis,
-           regex("(.*)/cluster.genesets.dir/summarise.geneset.analysis.sentinel"),
+         plots,
+         summariseGenesetAnalysis)
+@transform(plotRdimsFactors,
+           regex("(.*)/rdims.visualisation.dir/plot.rdims.factor.sentinel"),
            r"\1/latex.dir/report.vars.sty")
 def latexVars(infile, outfile):
     '''
@@ -2663,6 +2667,12 @@ def summaryReport(infile, outfile):
       \\input %(tenx_dir)s/pipelines/pipeline_seurat/markerReport.tex
       '''
 
+    if(PARAMS["genesets_active"]):
+        statement += '''
+        \\input %(tenx_dir)s/pipelines/pipeline_seurat/genesetSection.tex
+                     '''
+
+
     # When relevant, add section that compares
     # two conditions within each cluster
     if os.path.exists(
@@ -2672,6 +2682,12 @@ def summaryReport(infile, outfile):
         statement += '''
           \\input %(tenx_dir)s/pipelines/pipeline_seurat/%(wcc_section_name)s
           '''
+
+        if(PARAMS["genesets_active"]):
+            statement += '''
+        \\input %(tenx_dir)s/pipelines/pipeline_seurat/genesetBetweenSection.tex
+                         '''
+
 
     statement += '''\\input %(tenx_dir)s/latex/endmatter.tex'
     '''

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -521,7 +521,7 @@ def pagaPrepareInput(infile, outfile):
     log_file = outfile.replace("sentinel","log")
     reductiontype = PARAMS["dimreduction_method"]
 
-    if bool(re.search("sig", PARAMS["runspecs_n_components"])) :
+    if bool(re.search("sig", str(PARAMS["runspecs_n_components"]))) :
         comp="--usesigcomponents=TRUE"
     else :
         comp="--usesigcomponents=FALSE"

--- a/pipelines/pipeline_seurat/genesetBetweenSection.tex
+++ b/pipelines/pipeline_seurat/genesetBetweenSection.tex
@@ -1,3 +1,5 @@
+\section{Geneset enrichment analysis of within-cluster differentially expressed genes}
+
 A hypergeometric test is used to test for the enrichment of GO, KEGG and msigdb genesets amongst the positive marker genes for each cluster. The full results
 are available as a separate xlsx document.
 

--- a/pipelines/pipeline_seurat/markerReport.tex
+++ b/pipelines/pipeline_seurat/markerReport.tex
@@ -1,3 +1,1 @@
 \input{\tenxDir/pipelines/pipeline_seurat/markerGenes.tex}
-
-\input{\tenxDir/pipelines/pipeline_seurat/genesetSection.tex}

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -462,6 +462,10 @@ exprsreport:
 # (GO categories and KEGG pathways are analysed by default)
 
 genesets:
+  # Should geneset analysis be run?
+  # Choices True|False
+  active: True
+
   # Marker adjusted p-value threshold for it to be included in the geneset analysis (genesetAnalysis.R)
   # This value will also be used in the geneset analysis for within cluster DE
   marker_adjpthreshold: 0.1

--- a/pipelines/pipeline_seurat/withinClusterComparisonSection.tex
+++ b/pipelines/pipeline_seurat/withinClusterComparisonSection.tex
@@ -34,6 +34,3 @@ Key parameters are:
 \input{\conditionMarkerDEPlotsDir/characteriseClusterMarkersBetween}
 
 \clearpage
-
-\section{Geneset enrichment analysis of within-cluster differentially expressed genes}
-\input{\tenxDir/pipelines/pipeline_seurat/genesetBetweenSection.tex}


### PR DESCRIPTION
The PCA plots to visualise cellcycle effects have not been based
on the given cellcycle genes since the switch to Seurat v3 due to
the change of a parameter name in RunPCA from "pc.genes" to "features".
The parameter name is now updated. Please note that this means that
any cell cycle PCA plots made by the pipeline with Seurat v3 will
have been based on variable genes (which are the default features).

Also:
- Fix colors for violin plots of known genes with Leiden clustering
- Fix export of diffusion map coordinates
- Make geneset analysis optional
- Remove points from QC violin plots