### PR TITLE
Fix bug with calculation of per-condition mean expression

### DIFF
--- a/R/seurat_summariseMarkersBetween.R
+++ b/R/seurat_summariseMarkersBetween.R
@@ -104,8 +104,8 @@ for(cluster in clusters)
            de <- read.table(gzfile(res_fn), header=T, sep="\t", as.is=T)
            de <- de[order(de$p_va),]
 
-           ameans <- rowMeans(GetAssayData(object = s, slot="data")[de$gene,as, drop=FALSE])
-           bmeans <- rowMeans(GetAssayData(object = s, slot="data")[de$gene,bs, drop=FALSE])
+           ameans <- apply(expm1(GetAssayData(object = s, slot="data")[de$gene, as, drop=FALSE]), 1, mean)
+           bmeans <- apply(expm1(GetAssayData(object = s, slot="data")[de$gene, bs, drop=FALSE]), 1, mean)
 
            de[[aName]] <- ameans
            de[[bName]] <- bmeans


### PR DESCRIPTION
The mean expression values reported in the between conditions
summary tables were being incorrectly computed as the mean of the
logged values.