### PR TITLE
Option 'method' in runUMAP was not picked up

### DIFF
--- a/R/seurat_umap.R
+++ b/R/seurat_umap.R
@@ -71,7 +71,7 @@ if(opt$usesigcomponents)
 ## run UMAP
 message("RunUMAP")
 s <- RunUMAP(s,
-             method = opt$method,
+             umap.method = opt$method,
              reduction = opt$reductiontype,
              dims = comps,
              n.components = 2L,


### PR DESCRIPTION
Option name is 'umap.method' but our script was using 'method' . This was printed as a warning into log file.