### PR TITLE
improvements to pipeline_(seurat).py for large datasets

### DIFF
--- a/R/cellbrowser_prep.R
+++ b/R/cellbrowser_prep.R
@@ -46,7 +46,7 @@ annotation <- seurat_obj@misc
 
 ## Load UMAP coordinates
 cat("Load UMAP coordinates ... \n")
-data_selected = read.table(file.path(opt$seurat_path, opt$runspecs,"umap.dir", "umap.txt"),
+data_selected = read.table(file.path(opt$seurat_path, opt$runspecs,"umap.dir", "umap.tsv"),
                            header=TRUE, as.is=TRUE, sep="\t")
 data_selected$cluster = as.character(data_selected$cluster)
 output = data_selected[,c("barcode", "UMAP_1", "UMAP_2")]
@@ -56,7 +56,7 @@ write.table(output,file.path(opt$outdir, "UMAP.tsv"), quote = FALSE, row.names =
 
 ## Load Force-directed graph coordinates
 cat("Load Force-directed graph coordinates ... \n")
-infile_gzip = gzfile(file.path(opt$seurat_path, opt$runspecs,"paga.dir", "paga_init_fa2.txt.gz"))
+infile_gzip = gzfile(file.path(opt$seurat_path, opt$runspecs,"paga.dir", "paga_init_fa2.tsv.gz"))
 output = read.table(infile_gzip, header=TRUE, as.is=TRUE, sep="\t")
 colnames(output) = c("cellId", "x", "y")
 write.table(output,file.path(opt$outdir, "FA.tsv"), quote = FALSE, row.names = FALSE,
@@ -71,7 +71,7 @@ output = data_selected[,!grepl("UMAP", colnames(data_selected))] %>%
 write.table(output,file.path(opt$outdir, "meta.tsv"), quote = FALSE, row.names = FALSE,
             sep = "\t")
 
-## write out txt of expression for all included cells
+## write out.tsv of expression for all included cells
 cat("Prepare expression matrix ... \n")
 expr_data = as.data.frame(as.matrix(GetAssayData(seurat_obj, slot = "data")))
 expr_data = cbind(data.frame(gene=rownames(expr_data)),expr_data)
@@ -85,7 +85,7 @@ cat("Finished writing expression matrix ... \n")
 ## set the cell colors according to cluster
 cat("Read in the colors to match colors in other visualisations ... \n")
 
-cols = read.csv(file.path(opt$seurat_path, opt$runspecs, "cluster.dir", "cluster_colors.txt"),
+cols = read.csv(file.path(opt$seurat_path, opt$runspecs, "cluster.dir", "cluster_colors.tsv"),
                   header = FALSE, stringsAsFactors = FALSE)
 clusters = sort(unique(as.numeric(data_selected$cluster)))
 out_color = data.frame(name = clusters,

--- a/R/cellranger_postprocessAggrMatrix.R
+++ b/R/cellranger_postprocessAggrMatrix.R
@@ -20,7 +20,7 @@
 ##
 ## e.g.
 ##
-## $ cat samples.txt
+## $ cat samples.tsv
 ## sample_id          seq_id     agg_id
 ## d1_butyrate_mono   1          1
 ## d1_control_mono    1          2
@@ -40,7 +40,7 @@
 ## The script is run by specifying the location of the cellranger aggr matrix and the sample table, e.g.
 ## $ Rscript cellranger_cleanAggMatrix.R
 ##           --tenxdir=/gfs/work/ssansom/10x/holm_butyrate/agg/all_samples/outs/filtered_gene_bc_matrices_mex/GRCh38/
-##           --sampletable=samples.txt
+##           --sampletable=samples.tsv
 ##           --outdir=.
 
 message("cellranger_postprocessAggrMatrix.R")

--- a/R/export_for_python.R
+++ b/R/export_for_python.R
@@ -61,8 +61,8 @@ message("export_for_python running with default assay: ", DefaultAssay(s))
 
 # Write out the cell and feature names
 message("writing out the cell and feature names")
-writeLines(Cells(s), gzfile(file.path(opt$outdir,"barcodes.txt.gz")))
-writeLines(rownames(s), gzfile(file.path(opt$outdir,"features.txt.gz")))
+writeLines(Cells(s), gzfile(file.path(opt$outdir,"barcodes.tsv.gz")))
+writeLines(rownames(s), gzfile(file.path(opt$outdir,"features.tsv.gz")))
 
 # Write out embeddings (such as e.g. PCA)
 message("Writing matrix of reduced dimensions")
@@ -77,7 +77,7 @@ exportMetaData(s, outdir=opt$outdir)
 if (opt$usesigcomponents == TRUE) {
   message("Writing vector of significant components")
   comps <- getSigPC(s)
-  write.table(comps, file = paste0(opt$outdir, "/sig_comps.txt"),
+  write.table(comps, file = paste0(opt$outdir, "/sig_comps.tsv"),
               quote = FALSE, col.names = FALSE, row.names = FALSE)
 }
 

--- a/R/export_for_python.R
+++ b/R/export_for_python.R
@@ -46,6 +46,14 @@ exportEmbedding <- function(seurat_object, embedding="PCA", outdir=NULL) {
                 quote=FALSE, sep="\t", row.names = FALSE, col.names = TRUE)
     }
 
+exportMetaData <- function(seurat_object, outdir=NULL) {
+    x <- seurat_object[[]]
+    x$barcode <- Cells(seurat_object)
+    write.table(x, gzfile(file.path(outdir, "metadata.tsv.gz")),
+                quote=FALSE, sep="\t", row.names = FALSE, col.names = TRUE)
+    }
+
+
 # Read RDS seurat object
 message("readRDS")
 s <- readRDS(opt$seuratobject)
@@ -59,6 +67,11 @@ writeLines(rownames(s), gzfile(file.path(opt$outdir,"features.txt.gz")))
 # Write out embeddings (such as e.g. PCA)
 message("Writing matrix of reduced dimensions")
 exportEmbedding(s, opt$reductiontype, outdir=opt$outdir)
+
+# Write out the metadata
+message("Writing out the metadata")
+exportMetaData(s, outdir=opt$outdir)
+
 
 # Write out significant components
 if (opt$usesigcomponents == TRUE) {

--- a/R/fetch_geneset_annotations.R
+++ b/R/fetch_geneset_annotations.R
@@ -75,7 +75,7 @@ if(is.null(opt$ensembl_host))
 }
 
 write.table(anno,
-            gzfile(file.path(opt$outdir,"ensembl.to.entrez.txt.gz")),
+            gzfile(file.path(opt$outdir,"ensembl.to.entrez.tsv.gz")),
             quote=FALSE,
             row.names=FALSE,sep="\t")
 

--- a/R/genesetAnalysis.R
+++ b/R/genesetAnalysis.R
@@ -133,7 +133,7 @@ if(length(fg_entrez)>0)
         for(geneset in names(results))
             {
                 write.table(results[[geneset]],
-                            gzfile(paste(outPrefix,geneset,"txt","gz",sep=".")),
+                            gzfile(paste(outPrefix,geneset,"tsv","gz",sep=".")),
                             row.names=FALSE, col.names=TRUE, quote=FALSE,
                             sep="\t")
             }

--- a/R/paga_prepare_input.R
+++ b/R/paga_prepare_input.R
@@ -42,7 +42,7 @@ close(out)
 if (opt$usesigcomponents == TRUE) {
   message("Writing vector of significant components")
   comps <- getSigPC(s)
-  write.table(comps, file = paste0(opt$outdir, "/sig_comps.txt"), quote = FALSE, col.names = FALSE, row.names = FALSE)
+  write.table(comps, file = paste0(opt$outdir, "/sig_comps.tsv"), quote = FALSE, col.names = FALSE, row.names = FALSE)
 }
 
 message("paga_prepare_input.R final default assay: ", DefaultAssay(s))

--- a/R/plot_group_numbers.R
+++ b/R/plot_group_numbers.R
@@ -20,9 +20,13 @@ stopifnot(
 
 option_list <- list(
     make_option(
-      c("--table"),
+      c("--metadata"),
       default="none",
-      help="A table containing the grouping information"),
+      help="A table containing the metadata with grouping information"),
+    make_option(
+      c("--clusters"),
+      default="none",
+      help="A table containing the clusters"),
     make_option(
       c("--seuratobject"),
       default="none",
@@ -141,8 +145,28 @@ cat("Running with options:\n")
 print(opt)
 
 ## Read in the table with the grouping information
-data <- read.table(opt$table,sep="\t",header=T)
+data <- read.table(opt$metadata,sep="\t",header=T)
 rownames(data) <- data$barcode
+
+if(opt$cluster!="none")
+{
+
+
+    clusters <- read.table(opt$clusters, sep="\t", header=TRUE)
+    rownames(clusters) <- clusters$barcode
+    clusters$barcode <- NULL
+
+    if(!all(rownames(data) %in% rownames(clusters)))
+    {
+        stop("Not all cell barcodes are present in the given cluster table")
+    }
+
+    data$cluster <- clusters[rownames(data), "cluster_id"]
+
+
+}
+
+
 
 
 ## ########################################################################### #

--- a/R/plot_group_numbers.R
+++ b/R/plot_group_numbers.R
@@ -4,24 +4,6 @@
 ##
 ## Description ----
 ##
-## For the given grouping variables, make plots of
-## (i) numbers of cells
-## (ii) fractions of cells
-## (iii) ngenes/cell
-## (iv) ncounts/cell.
-##
-## Details ----
-##
-## Only grouping factors with more than one level are plotted.
-##
-## Usage ----
-##
-## $ Rscript getGenesetAnnotations.R
-##           --table=grouping.factors.txt
-##           --seuratobject=seurat.Robj
-##           --groupfactors=cluster
-##           --subgroupfactors=patient
-##           --outdir=.
 
 # Libraries ----
 
@@ -30,8 +12,6 @@ stopifnot(
   require(ggplot2),
   require(reshape2),
   require(dplyr),
-  require(Seurat),
-  require(gridExtra),
   require(tenxutils),
   require(colormap)
 )
@@ -54,15 +34,88 @@ option_list <- list(
       help="The seurat assay from which the counts will be retrieved",
       ),
     make_option(
-      c("--subgroupfactor"),
+      c("--title"),
       default="none",
-      help="A column in the cell metadata used to define subgroups e.g. the condition"
+      help="Used for the filename"
       ),
     make_option(
-      c("--groupfactors"),
+      c("--group"),
       default="none",
-      help="Column(s) in the cell metadata to use for grouping, e.g. cluster or State"
+      help="A column in the cell metadata used to define the groups"
+      ),
+    make_option(
+      c("--subgroup"),
+      default="none",
+      help="Column(s) in the cell metadata for subgroup"
     ),
+    make_option(
+      c("--subgrouplevels"),
+      default=NULL,
+      help="the subgroup levels in order, comma separated"
+    ),
+    make_option(
+        c("--facet"),
+        default=FALSE,
+        action="store_true",
+        help="Facet the plot by group."
+    ),
+    make_option(
+        c("--freey"),
+        default=FALSE,
+        action="store_true",
+        help='should the y scale be free when facetting?'
+    ),
+    make_option(
+        c("--ncol"),
+        default=5,
+        type="integer",
+        help='should the y scale be free when facetting?'
+    ),
+    make_option(
+        c("--replicate"),
+        default="none",
+        help="Column in the cell metadata used to define the replicates"
+    ),
+    make_option(
+        c("--xlab"),
+        default=NULL,
+        help="x axis label"
+    ),
+    make_option(
+        c("--ylab"),
+        default=NULL,
+        help="y axis label"
+    ),
+    make_option(
+        c("--stat"),
+        default="none",
+        help=paste('The statistic to be plotted. Either:',
+                   '(1) A column name in the metadata',
+                   '(2) "total_UMI" or "ngenes" which will be computed from the seurat object, if not in the metadata',
+                   '(3) the summary stats "count" or "pct" which will be computed by dplyr'),
+    ),
+    make_option(
+      c("--geom"),
+      default="bar",
+      help='"bar" or "boxplot"'
+    ),
+    make_option(
+      c("--trans"),
+      default=NULL,
+      help='Currently only sqrt is supported, applied to y'
+      ),
+    make_option(
+      c("--width"),
+      default=7,
+      type="double",
+      help="the width of the plot"
+      ),
+    make_option(
+      c("--height"),
+      default=7,
+      type="double",
+      help="the width of the plot"
+      ),
     make_option(
       c("--plotdirvar"),
       default="groupNumbersDir",
@@ -71,7 +124,15 @@ option_list <- list(
     make_option(
       c("--outdir"),
       default="seurat.out.dir",
-      help="outdir")
+      help="outdir"),
+    make_option(
+      c("--pdf"),
+      default=FALSE,
+      help="outdir"),
+    make_option(
+      c("--savedata"),
+      default=FALSE,
+      help="should the plot data be saved?")
     )
 
 opt <- parse_args(OptionParser(option_list=option_list))
@@ -83,316 +144,239 @@ print(opt)
 data <- read.table(opt$table,sep="\t",header=T)
 rownames(data) <- data$barcode
 
-group_vars_all <- strsplit(opt$groupfactors,",")[[1]]
-opt$subgroupfactor <- strsplit(opt$subgroupfactor, ",")[[1]]
-tex = ""
 
-## Drop grouping variables
-## that only have one level
-group_vars <- c()
-for(group_var in group_vars_all)
+## ########################################################################### #
+## ########################## Add missing stats ############################## #
+## ########################################################################### #
+
+if(opt$stat %in% c("total_UMI", "ngenes"))
 {
-
-    data[[group_var]] <- as.factor(data[[group_var]])
-
-    if(length(levels(data[[group_var]]))>1)
+    if(!opt$stat %in% colnames(data))
     {
-        group_vars <- c(group_vars, group_var)
+        require(Seurat)
+        # add the statistic from the seurat object
+        s <- readRDS(opt$seuratobject)
+
+        ## set the default assay
+        message("Setting default assay to: ", opt$seuratassay)
+        DefaultAssay(s) <- opt$seuratassay
+
+        message("plot_group_numbers.R running with default assay: ", DefaultAssay(s))
+
+        cdata <- GetAssayData(object = s, slot = "counts")
+
+        if(stat=="ngenes")
+        {
+            ngenes <- Matrix::colSums(cdata>0)
+            data$ngenes <- ngenes[rownames(data)]
+        }
+        else if(stat=="total_UMI")
+        {
+            total_UMI <- Matrix::colSums(cdata)
+            data$total_UMI <- total_UMI[rownames(data)]
+        } else { stop("stat not recognised") }
+        # free the memory.
+        rm(s)
     }
 }
 
-# Plot cell counts and fractions ----
-## Make one whole-page plot per grouping variable
-for(group_var in group_vars)
+## ########################################################################### #
+## ################ summarise the data for plotting ########################## #
+## ########################################################################### #
+
+# define the grouping variables
+group_vars = c(opt$group, opt$subgroup, opt$replicate)
+group_vars <- group_vars[!group_vars=="none"]
+
+message("using group variables")
+print(group_vars)
+
+## check the group variables are in the data columns
+for(gvar in group_vars)
 {
-    message("doing cell counts and fractions plots for group ",group_var)
-
-    if(opt$subgroupfactor=="none" | !(opt$subgroupfactor %in% colnames(data)))
+    if(!gvar %in% colnames(data))
     {
-      message("no subgroup found")
-
-        plot_data <- data %>% group_by_(group_var) %>% summarise(count=n()) %>% mutate(proportion= count/sum(count))
-
-        cm_palette <- colormap(colormap = colormaps$portland,
-                             nshade = 2, alpha=0.6)
-
-        gp1 <- ggplot(plot_data, aes_string(group_var, "count"))
-        gp1 <- gp1 + geom_bar(stat="identity")
-
-        gp2 <- ggplot(plot_data, aes_string(group_var,"proportion"))
-        gp2 <- gp2 + geom_bar(stat="identity")
+        stop(paste("Grouping variable: ", gvar," not found in data"))
+    }
+}
 
 
-        gp1 <- gp1 + scale_fill_manual(values=cm_palette) #c("seagreen4","bisque2",")
-        gp1 <- gp1 + xlab(group_var)
-        gp1 <- gp1 + ylab("number of cells")
+if(opt$stat=="count")
+{
+    plot_data <- data %>%
+        group_by_at(group_vars) %>%
+        summarise(count=n())
 
-
-        gp2 <- gp2 + scale_fill_manual(values=cm_palette) #c("seagreen4","bisque2",")
-        gp2 <- gp2 + xlab(group_var)
-        gp2 <- gp2 + scale_y_continuous(labels=scales::percent)
-        gp2 <- gp2 + ylab("percentage of cells")
-
-      gp1 <- gp1 + theme_light()
-      gp2 <- gp2 + theme_light()
-
-        gps <- list(gp1, gp2)
-
-        g <- grid.arrange(grobs=gps, ncols=1)
-
-        plot_title <- paste("numbers","group_stats",group_var,sep=".")
-
-        plotfilename <- paste(plot_title, sep=".")
-
-        save_ggplots(file.path(opt$outdir, plotfilename),
-                     g,
-                     width=6,
-                     height=4)
-
-        # save the plot data.
-        write.table(plot_data,
-                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
-                    col.names=TRUE,
-                    row.names=FALSE,
-                    quote=FALSE,
-                    sep="\t")
-
-        tex <- c(tex,
-                 getSubsectionTex(paste("Cell numbers by",group_var)))
-
-        tex <- c(tex,
-                 getFigureTex(plotfilename,
-                              plot_title,
-                              plot_dir_var=opt$plotdirvar),
-                 sep="\n")
-
-
-
-    } else {
-      for ( subgroup in opt$subgroupfactor){
-        message("doing cell counts and fractions plots for group ",group_var, " and subgroup ", subgroup)
+} else if (opt$stat == "pct") {
+    if(opt$replicate=="none")
+    {
+        ## this the within group percent.
+        ## to normalise across groups, specify a replicate factor.
 
         plot_data <- data %>%
-              group_by_at(.vars=c(subgroup, group_var)) %>%
-              summarise(count=n()) %>%
-              mutate(proportion= count/sum(count))
-
-        # plot_data <- data %>% group_by_at(.vars=c(subgroup, group_var)) %>% summarise(count=n()) %>%
-        #   group_by_at(.vars=group_var) %>%
-        #   mutate(proportion= count/sum(count)) (this would do the percentage for each class within its x variable group)
-
-        # filler<-gtools::mixedsort(unique(as.character(pull(plot_data,subgroup))))
-        nsubgroup <- length(unique(plot_data[[subgroup]]))
-        cm_palette <- colormap(colormap = colormaps$portland,
-                               nshade = nsubgroup, alpha=0.6)
-
-
-        gp1 <- ggplot(plot_data, aes_string(group_var, "count", group="count", fill=subgroup))
-        gp1 <- gp1 + geom_bar(stat="identity", position="dodge")
-
-        gp2 <- ggplot(plot_data, aes_string(group_var, "proportion", group="count", fill=subgroup))
-        gp2 <- gp2 + geom_bar(stat="identity", position="dodge")
-
-
-        gp1 <- gp1 + scale_fill_manual(values=cm_palette)
-
-        gp1 <- gp1 + xlab(group_var)
-        gp1 <- gp1 + ylab("number of cells")
-
-
-        gp2 <- gp2 + scale_fill_manual(values=cm_palette) #scale_fill_viridis_d(breaks=filler, limits=filler)
-        gp2 <- gp2 + xlab(group_var)
-        gp2 <- gp2 + scale_y_continuous(labels=scales::percent)
-        gp2 <- gp2 + ylab("percentage of cells")
-
-        if(nsubgroup > 6 ) {
-          gp2 <-gp2 + theme(legend.position = "bottom",
-                            legend.key.height = unit(0.1,"in"),
-                            legend.text = element_text(size=7))
-          gp1 <-gp1 + theme(legend.position = "bottom",
-                            legend.key.height = unit(0.1,"in"),
-                            legend.text = element_text(size=7))
-        }
-
-        gp1 <- gp1 + theme_light()
-        gp2 <- gp2 + theme_light()
-
-        gps <- list(gp1, gp2)
-
-        g <- grid.arrange(grobs=gps, ncols=1)
-
-        plot_title <- paste("numbers","group_stats",group_var,"split_by",subgroup,sep=".")
-
-        plotfilename <- paste(plot_title, sep=".") #not necessary
-
-        save_ggplots(file.path(opt$outdir, plotfilename),
-                     g,
-                     width=7,
-                     height=5)
-
-        # save the plot data.
-        write.table(plot_data,
-                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
-                    col.names=TRUE,
-                    row.names=FALSE,
-                    quote=FALSE,
-                    sep="\t")
-
-        tex <- c(tex,
-                 getSubsectionTex(paste("Cell numbers by",group_var)))
-
-        tex <- c(tex,
-                 getFigureTex(plotfilename,
-                              plot_title,
-                              plot_dir_var=opt$plotdirvar),
-                 sep="\n")
-
-
-
-        }
-
-    }
-
-
-    ## http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
-    ## The palette with grey:
-
-}
-
-
-# Plot numbers of genes/cell and counts/cell ----
-
-s <- readRDS(opt$seuratobject)
-
-## set the default assay
-message("Setting default assay to: ", opt$seuratassay)
-DefaultAssay(s) <- opt$seuratassay
-
-message("plot_group_numbers.R running with default assay: ", DefaultAssay(s))
-
-cdata <- GetAssayData(object = s, slot = "counts")
-
-# ngenes <- apply(cdata,2,function(x) sum(x>0))
-# ncounts <- apply(cdata,2,sum)
-ngenes <- Matrix::colSums(cdata>0)
-ncounts <- Matrix::colSums(cdata)
-
-
-cinfo <- data.frame(ngenes=ngenes,ncounts=ncounts)
-
-data <- merge(data,cinfo,by=0)
-
-## Make one whole-page plot per grouping variable
-for(group_var in group_vars)
-{
-    message("doing genes and counts per-cell plots for group ",group_var)
-
-    if(opt$subgroupfactor=="none" | !(opt$subgroupfactor %in% colnames(data)))
-    {
-      message("no subgroup found")
-
-      cm_palette <- colormap(colormap = colormaps$portland,
-                               nshade = 2, alpha=0.6)
-
-      gp1 <- ggplot(data, aes_string(group_var,"ngenes"))  + geom_boxplot()
-      gp1 <-gp1 + xlab(group_var) + ylab("number of genes per cell")
-
-      gp2 <- ggplot(data, aes_string(group_var,"ncounts"))  + geom_boxplot()
-      gp2 <- gp2 + xlab(group_var) + ylab("raw counts per cell")
-
-      gp1 <- gp1 + scale_fill_manual(values=cm_palette) ## c("seagreen4","bisque2"))
-      gp2 <- gp2 + scale_fill_manual(values=cm_palette) ## c("seagreen4","bisque2"))
-
-      gp1 <- gp1 + theme_light()
-      gp2 <- gp2 + theme_light()
-
-
-      gps <- list(gp1, gp2)
-
-      g <- grid.arrange(grobs=gps, ncols=1)
-
-      plot_title <- paste("numbers", "cell_stats", group_var, sep=".")
-
-      plotfilename <- plot_title
-
-      save_ggplots(file.path(opt$outdir, plotfilename),
-                   g,
-                   width=6,
-                   height=8)
-
-      tex <- c(tex,
-               getSubsectionTex(paste("Gene and UMIs by",group_var)))
-
-      tex <- c(tex,
-               getFigureTex(plotfilename, plot_title,
-                            plot_dir_var=opt$plotdirvar),
-               sep="\n")
-
+            group_by_at(group_vars) %>%
+            summarise(count=n()) %>%
+            mutate(pct=(count/sum(count))*100)
 
     } else {
-      for ( subgroup in opt$subgroupfactor){
-        message("doing cell counts and fractions plots for group ",group_var, " and subgroup ", subgroup)
+        plot_data <- data %>% add_count((!!as.name(opt$replicate)), name="rep_n")
+        message("head plot data after adding replicate count column")
 
-                                        # filler <- gtools::mixedsort(unique(as.character(data[,subgroup])))
+        print(plot_data[,c(colnames(plot_data)[1:5],"rep_n")])
 
-        nsubgroup <- length(unique(plot_data[[subgroup]]))
-        cm_palette <- colormap(colormap = colormaps$portland,
-                               nshade = nsubgroup, alpha=0.6)
+        plot_data <- plot_data %>%
+            group_by_at(group_vars) %>%
+            summarise(count=n(), n=mean(rep_n)) %>%
+            mutate(pct=(count/n)*100)
 
-        gp1 <- ggplot(data, aes_string(group_var,"ngenes" ,fill=subgroup))  + geom_boxplot()
-        gp1 <-gp1 + xlab(group_var) + ylab("number of genes per cell")
+        ## check that the percentages by replicate add to 100
+        check <- plot_data %>%
+            group_by_at(opt$replicate) %>%
+            summarise(total_pct=sum(pct))
 
-        gp2 <- ggplot(data, aes_string(group_var,"ncounts" ,fill=subgroup))  + geom_boxplot()
-        gp2 <- gp2 + xlab(group_var) + ylab("raw counts per cell")
-        gp1 <- gp1 + scale_fill_manual(values=cm_palette)
-        gp2 <- gp2 + scale_fill_manual(values=cm_palette)
-        gp1 <- gp1 + theme_light()
-        gp2 <- gp2 + theme_light()
+        if(mean(check$total_pct) != 100) { stop("pcts do not sum to 100") }
 
-        if(nsubgroup > 6 ) {
-          gp2 <-gp2 + theme(legend.position = "bottom",
-                            legend.key.height = unit(0.1,"in"),
-                            legend.text = element_text(size=7))
-          gp1 <-gp1 + theme(legend.position = "bottom",
-                            legend.key.height = unit(0.1,"in"),
-                            legend.text = element_text(size=7))
-        }
-
-        gp1 <- gp1 + theme_light()
-        gp2 <- gp2 + theme_light()
-
-        gps <- list(gp1, gp2)
-
-        g <- grid.arrange(grobs=gps, ncols=1)
-
-        plot_title <- paste("numbers", "cell_stats", group_var, "split_by", subgroup, sep=".")
-
-        plotfilename <- plot_title
-
-        save_ggplots(file.path(opt$outdir, plotfilename),
-                     g,
-                     width=6,
-                     height=8)
-
-        tex <- c(tex,
-                 getSubsectionTex(paste("Gene and UMIs by",group_var)))
-
-        tex <- c(tex,
-                 getFigureTex(plotfilename, plot_title,
-                              plot_dir_var=opt$plotdirvar),
-                 sep="\n")
-
-      }
+        message("head of pct check tibble")
+        print(check)
 
     }
+} else if (!opt$stat %in% colnames(data)) {
+    stop("The requested statistic is not recognised or present in the metadata")
+} else {
 
+    if(opt$replicate=="none")
+    {
+        stop("A replicate column must be specified when plotting by a named column")
+
+        } else {
+    ## no need to summarise, plotting boxplots on column in data.
+
+            plot_data <- data
+            }
+}
+
+message("head of the plot data..")
+print(head(plot_data))
+
+
+## ########################################################################### #
+## ######################## draw out the plots ############################### #
+## ########################################################################### #
+
+
+## set the x and fill variables.
+if(opt$subgroup == "none")
+{
+            subgroup <- FALSE
+            xvar <- opt$group
+            fvar <- opt$group
+
+} else {
+    subgroup <- TRUE
+
+    if(!is.null(opt$subgrouplevels))
+        {
+            sgl = strsplit(gsub(" ","", opt$subgrouplevels),",")[[1]]
+
+            if(!all(sgl  %in% unique(plot_data[[opt$subgroup]])))
+            {
+                stop("given levels do not match levels present in subgroup")
+            }
+
+            plot_data[[opt$subgroup]] <- factor(plot_data[[opt$subgroup]],
+                                                levels = sgl)
+        }
+
+    fvar <- opt$subgroup
+    if(opt$facet)
+        {
+            xvar <- opt$subgroup
+        } else { xvar <- opt$group }
 
 }
 
-## write out latex snippet
-writeTex(file.path(opt$outdir, paste("number","plots","tex", sep=".")),
-         tex)
+message("fvar: ", fvar)
+message("xvar: ", xvar)
 
-message("plot_group_numbers.R final default assay: ", DefaultAssay(s))
+## convert numeric x factor to char with correct ordering
+if(is.numeric(plot_data[[xvar]]))
+{
+
+    x <- plot_data[[xvar]]
+    num_levels = unique(x)
+    char_levels = as.character(num_levels)
+    char_levels = char_levels[order(num_levels)]
+
+    plot_data[[xvar]] <- factor(as.character(plot_data[[xvar]]),
+                                   levels=char_levels)
+
+}
+
+gp <- ggplot(plot_data, aes_string(xvar, opt$stat, fill=fvar))
+
+if(opt$geom == "bar")
+{
+    message(" drawing bar plots")
+
+    gp <- gp + geom_bar(stat="identity", position="dodge")
+
+
+} else if(opt$geom == "boxplot") {
+    message("drawing box plots")
+
+    gp <- gp + geom_boxplot()
+
+} else { stop("geom not supported") }
+
+## optional facetting
+if(subgroup && opt$facet) {
+    if(opt$freey)
+        {
+            gp <- gp + facet_wrap(formula(paste("~",opt$group,sep="")), scales="free_y", ncol=opt$ncol)
+        } else {
+            gp <- gp + facet_wrap(formula(paste("~",opt$group,sep="")),ncol=opt$ncol)
+            }
+
+}
+
+gp <- gp + theme_light()
+
+## sort out the colors
+nsubgroup <- length(unique(plot_data[[fvar]]))
+cm_palette <- colormap(colormap = colormaps$portland,
+                           nshade = nsubgroup, alpha=0.6)
+
+gp <- gp + scale_fill_manual(values=cm_palette) #c("seagreen4","bisque2",")
+
+## optional y axis transformation
+if(!is.null(opt$trans))
+{
+    if(opt$trans=="sqrt")
+    {    gp <- gp + scale_y_continuous(trans=opt$trans)
+    } else { stop("given transformation not implemented") }
+}
+
+
+## tidy up the axis labels.
+gp <- gp + theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust=1))
+
+if(!is.null(opt$xlab)) { gp <- gp + xlab(opt$xlab) }
+if(!is.null(opt$ylab)) { gp <- gp + ylab(opt$ylab) }
+
+
+## save the plots
+save_ggplots(file.path(opt$outdir, opt$title),
+             gp,
+             width=opt$width,
+             height=opt$height,
+             to_pdf=opt$pdf)
+
+
+## optionally save the plot data
+if(opt$savedata)
+    {
+        write.table(plot_data, gzfile("plot.data.tsv.gz"),
+                    sep="\t", col.names=T, row.names=F, quote=F)
+}
 
 message("completed")

--- a/R/plot_group_numbers.R
+++ b/R/plot_group_numbers.R
@@ -135,7 +135,7 @@ option_list <- list(
       help="outdir"),
     make_option(
       c("--savedata"),
-      default=FALSE,
+      default=TRUE,
       help="should the plot data be saved?")
     )
 
@@ -398,9 +398,11 @@ save_ggplots(file.path(opt$outdir, opt$title),
 
 ## optionally save the plot data
 if(opt$savedata)
-    {
-        write.table(plot_data, gzfile("plot.data.tsv.gz"),
-                    sep="\t", col.names=T, row.names=F, quote=F)
+{
+    data_file <- file.path(opt$outdir,
+                           paste(opt$title, "data.tsv.gz", sep="."))
+    write.table(plot_data, gzfile(data_file),
+                sep="\t", col.names=T, row.names=F, quote=F)
 }
 
 message("completed")

--- a/R/plot_group_numbers_old.R
+++ b/R/plot_group_numbers_old.R
@@ -1,0 +1,398 @@
+## Title ----
+##
+## Visualise the numbers of single-cells falling into different groups
+##
+## Description ----
+##
+## For the given grouping variables, make plots of
+## (i) numbers of cells
+## (ii) fractions of cells
+## (iii) ngenes/cell
+## (iv) ncounts/cell.
+##
+## Details ----
+##
+## Only grouping factors with more than one level are plotted.
+##
+## Usage ----
+##
+## $ Rscript getGenesetAnnotations.R
+##           --table=grouping.factors.txt
+##           --seuratobject=seurat.Robj
+##           --groupfactors=cluster
+##           --subgroupfactors=patient
+##           --outdir=.
+
+# Libraries ----
+
+stopifnot(
+  require(optparse),
+  require(ggplot2),
+  require(reshape2),
+  require(dplyr),
+  require(Seurat),
+  require(gridExtra),
+  require(tenxutils),
+  require(colormap)
+)
+
+# Options ----
+
+option_list <- list(
+    make_option(
+      c("--table"),
+      default="none",
+      help="A table containing the grouping information"),
+    make_option(
+      c("--seuratobject"),
+      default="none",
+      help="The seurat object (typically begin.rds)"
+    ),
+    make_option(
+      c("--seuratassay"),
+      default="RNA",
+      help="The seurat assay from which the counts will be retrieved",
+      ),
+    make_option(
+      c("--subgroupfactor"),
+      default="none",
+      help="A column in the cell metadata used to define subgroups e.g. the condition"
+      ),
+    make_option(
+      c("--groupfactors"),
+      default="none",
+      help="Column(s) in the cell metadata to use for grouping, e.g. cluster or State"
+    ),
+    make_option(
+      c("--plotdirvar"),
+      default="groupNumbersDir",
+      help="the latex var holding the name of the dir with the plots"
+      ),
+    make_option(
+      c("--outdir"),
+      default="seurat.out.dir",
+      help="outdir")
+    )
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+cat("Running with options:\n")
+print(opt)
+
+## Read in the table with the grouping information
+data <- read.table(opt$table,sep="\t",header=T)
+rownames(data) <- data$barcode
+
+group_vars_all <- strsplit(opt$groupfactors,",")[[1]]
+opt$subgroupfactor <- strsplit(opt$subgroupfactor, ",")[[1]]
+tex = ""
+
+## Drop grouping variables
+## that only have one level
+group_vars <- c()
+for(group_var in group_vars_all)
+{
+
+    data[[group_var]] <- as.factor(data[[group_var]])
+
+    if(length(levels(data[[group_var]]))>1)
+    {
+        group_vars <- c(group_vars, group_var)
+    }
+}
+
+# Plot cell counts and fractions ----
+## Make one whole-page plot per grouping variable
+for(group_var in group_vars)
+{
+    message("doing cell counts and fractions plots for group ",group_var)
+
+    if(opt$subgroupfactor=="none" | !(opt$subgroupfactor %in% colnames(data)))
+    {
+      message("no subgroup found")
+
+        plot_data <- data %>% group_by_(group_var) %>% summarise(count=n()) %>% mutate(proportion= count/sum(count))
+
+        cm_palette <- colormap(colormap = colormaps$portland,
+                             nshade = 2, alpha=0.6)
+
+        gp1 <- ggplot(plot_data, aes_string(group_var, "count"))
+        gp1 <- gp1 + geom_bar(stat="identity")
+
+        gp2 <- ggplot(plot_data, aes_string(group_var,"proportion"))
+        gp2 <- gp2 + geom_bar(stat="identity")
+
+
+        gp1 <- gp1 + scale_fill_manual(values=cm_palette) #c("seagreen4","bisque2",")
+        gp1 <- gp1 + xlab(group_var)
+        gp1 <- gp1 + ylab("number of cells")
+
+
+        gp2 <- gp2 + scale_fill_manual(values=cm_palette) #c("seagreen4","bisque2",")
+        gp2 <- gp2 + xlab(group_var)
+        gp2 <- gp2 + scale_y_continuous(labels=scales::percent)
+        gp2 <- gp2 + ylab("percentage of cells")
+
+      gp1 <- gp1 + theme_light()
+      gp2 <- gp2 + theme_light()
+
+        gps <- list(gp1, gp2)
+
+        g <- grid.arrange(grobs=gps, ncols=1)
+
+        plot_title <- paste("numbers","group_stats",group_var,sep=".")
+
+        plotfilename <- paste(plot_title, sep=".")
+
+        save_ggplots(file.path(opt$outdir, plotfilename),
+                     g,
+                     width=6,
+                     height=4)
+
+        # save the plot data.
+        write.table(plot_data,
+                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
+                    col.names=TRUE,
+                    row.names=FALSE,
+                    quote=FALSE,
+                    sep="\t")
+
+        tex <- c(tex,
+                 getSubsectionTex(paste("Cell numbers by",group_var)))
+
+        tex <- c(tex,
+                 getFigureTex(plotfilename,
+                              plot_title,
+                              plot_dir_var=opt$plotdirvar),
+                 sep="\n")
+
+
+
+    } else {
+      for ( subgroup in opt$subgroupfactor){
+        message("doing cell counts and fractions plots for group ",group_var, " and subgroup ", subgroup)
+
+        plot_data <- data %>%
+              group_by_at(.vars=c(subgroup, group_var)) %>%
+              summarise(count=n()) %>%
+              mutate(proportion= count/sum(count))
+
+        # plot_data <- data %>% group_by_at(.vars=c(subgroup, group_var)) %>% summarise(count=n()) %>%
+        #   group_by_at(.vars=group_var) %>%
+        #   mutate(proportion= count/sum(count)) (this would do the percentage for each class within its x variable group)
+
+        # filler<-gtools::mixedsort(unique(as.character(pull(plot_data,subgroup))))
+        nsubgroup <- length(unique(plot_data[[subgroup]]))
+        cm_palette <- colormap(colormap = colormaps$portland,
+                               nshade = nsubgroup, alpha=0.6)
+
+
+        gp1 <- ggplot(plot_data, aes_string(group_var, "count", group="count", fill=subgroup))
+        gp1 <- gp1 + geom_bar(stat="identity", position="dodge")
+
+        gp2 <- ggplot(plot_data, aes_string(group_var, "proportion", group="count", fill=subgroup))
+        gp2 <- gp2 + geom_bar(stat="identity", position="dodge")
+
+
+        gp1 <- gp1 + scale_fill_manual(values=cm_palette)
+
+        gp1 <- gp1 + xlab(group_var)
+        gp1 <- gp1 + ylab("number of cells")
+
+
+        gp2 <- gp2 + scale_fill_manual(values=cm_palette) #scale_fill_viridis_d(breaks=filler, limits=filler)
+        gp2 <- gp2 + xlab(group_var)
+        gp2 <- gp2 + scale_y_continuous(labels=scales::percent)
+        gp2 <- gp2 + ylab("percentage of cells")
+
+        if(nsubgroup > 6 ) {
+          gp2 <-gp2 + theme(legend.position = "bottom",
+                            legend.key.height = unit(0.1,"in"),
+                            legend.text = element_text(size=7))
+          gp1 <-gp1 + theme(legend.position = "bottom",
+                            legend.key.height = unit(0.1,"in"),
+                            legend.text = element_text(size=7))
+        }
+
+        gp1 <- gp1 + theme_light()
+        gp2 <- gp2 + theme_light()
+
+        gps <- list(gp1, gp2)
+
+        g <- grid.arrange(grobs=gps, ncols=1)
+
+        plot_title <- paste("numbers","group_stats",group_var,"split_by",subgroup,sep=".")
+
+        plotfilename <- paste(plot_title, sep=".") #not necessary
+
+        save_ggplots(file.path(opt$outdir, plotfilename),
+                     g,
+                     width=7,
+                     height=5)
+
+        # save the plot data.
+        write.table(plot_data,
+                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
+                    col.names=TRUE,
+                    row.names=FALSE,
+                    quote=FALSE,
+                    sep="\t")
+
+        tex <- c(tex,
+                 getSubsectionTex(paste("Cell numbers by",group_var)))
+
+        tex <- c(tex,
+                 getFigureTex(plotfilename,
+                              plot_title,
+                              plot_dir_var=opt$plotdirvar),
+                 sep="\n")
+
+
+
+        }
+
+    }
+
+
+    ## http://www.cookbook-r.com/Graphs/Colors_(ggplot2)/
+    ## The palette with grey:
+
+}
+
+
+# Plot numbers of genes/cell and counts/cell ----
+
+s <- readRDS(opt$seuratobject)
+
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("plot_group_numbers.R running with default assay: ", DefaultAssay(s))
+
+cdata <- GetAssayData(object = s, slot = "counts")
+
+# ngenes <- apply(cdata,2,function(x) sum(x>0))
+# ncounts <- apply(cdata,2,sum)
+ngenes <- Matrix::colSums(cdata>0)
+ncounts <- Matrix::colSums(cdata)
+
+
+cinfo <- data.frame(ngenes=ngenes,ncounts=ncounts)
+
+data <- merge(data,cinfo,by=0)
+
+## Make one whole-page plot per grouping variable
+for(group_var in group_vars)
+{
+    message("doing genes and counts per-cell plots for group ",group_var)
+
+    if(opt$subgroupfactor=="none" | !(opt$subgroupfactor %in% colnames(data)))
+    {
+      message("no subgroup found")
+
+      cm_palette <- colormap(colormap = colormaps$portland,
+                               nshade = 2, alpha=0.6)
+
+      gp1 <- ggplot(data, aes_string(group_var,"ngenes"))  + geom_boxplot()
+      gp1 <-gp1 + xlab(group_var) + ylab("number of genes per cell")
+
+      gp2 <- ggplot(data, aes_string(group_var,"ncounts"))  + geom_boxplot()
+      gp2 <- gp2 + xlab(group_var) + ylab("raw counts per cell")
+
+      gp1 <- gp1 + scale_fill_manual(values=cm_palette) ## c("seagreen4","bisque2"))
+      gp2 <- gp2 + scale_fill_manual(values=cm_palette) ## c("seagreen4","bisque2"))
+
+      gp1 <- gp1 + theme_light()
+      gp2 <- gp2 + theme_light()
+
+
+      gps <- list(gp1, gp2)
+
+      g <- grid.arrange(grobs=gps, ncols=1)
+
+      plot_title <- paste("numbers", "cell_stats", group_var, sep=".")
+
+      plotfilename <- plot_title
+
+      save_ggplots(file.path(opt$outdir, plotfilename),
+                   g,
+                   width=6,
+                   height=8)
+
+      tex <- c(tex,
+               getSubsectionTex(paste("Gene and UMIs by",group_var)))
+
+      tex <- c(tex,
+               getFigureTex(plotfilename, plot_title,
+                            plot_dir_var=opt$plotdirvar),
+               sep="\n")
+
+
+    } else {
+      for ( subgroup in opt$subgroupfactor){
+        message("doing cell counts and fractions plots for group ",group_var, " and subgroup ", subgroup)
+
+                                        # filler <- gtools::mixedsort(unique(as.character(data[,subgroup])))
+
+        nsubgroup <- length(unique(plot_data[[subgroup]]))
+        cm_palette <- colormap(colormap = colormaps$portland,
+                               nshade = nsubgroup, alpha=0.6)
+
+        gp1 <- ggplot(data, aes_string(group_var,"ngenes" ,fill=subgroup))  + geom_boxplot()
+        gp1 <-gp1 + xlab(group_var) + ylab("number of genes per cell")
+
+        gp2 <- ggplot(data, aes_string(group_var,"ncounts" ,fill=subgroup))  + geom_boxplot()
+        gp2 <- gp2 + xlab(group_var) + ylab("raw counts per cell")
+        gp1 <- gp1 + scale_fill_manual(values=cm_palette)
+        gp2 <- gp2 + scale_fill_manual(values=cm_palette)
+        gp1 <- gp1 + theme_light()
+        gp2 <- gp2 + theme_light()
+
+        if(nsubgroup > 6 ) {
+          gp2 <-gp2 + theme(legend.position = "bottom",
+                            legend.key.height = unit(0.1,"in"),
+                            legend.text = element_text(size=7))
+          gp1 <-gp1 + theme(legend.position = "bottom",
+                            legend.key.height = unit(0.1,"in"),
+                            legend.text = element_text(size=7))
+        }
+
+        gp1 <- gp1 + theme_light()
+        gp2 <- gp2 + theme_light()
+
+        gps <- list(gp1, gp2)
+
+        g <- grid.arrange(grobs=gps, ncols=1)
+
+        plot_title <- paste("numbers", "cell_stats", group_var, "split_by", subgroup, sep=".")
+
+        plotfilename <- plot_title
+
+        save_ggplots(file.path(opt$outdir, plotfilename),
+                     g,
+                     width=6,
+                     height=8)
+
+        tex <- c(tex,
+                 getSubsectionTex(paste("Gene and UMIs by",group_var)))
+
+        tex <- c(tex,
+                 getFigureTex(plotfilename, plot_title,
+                              plot_dir_var=opt$plotdirvar),
+                 sep="\n")
+
+      }
+
+    }
+
+
+}
+
+## write out latex snippet
+writeTex(file.path(opt$outdir, paste("number","plots","tex", sep=".")),
+         tex)
+
+message("plot_group_numbers.R final default assay: ", DefaultAssay(s))
+
+message("completed")

--- a/R/plot_group_numbers_old.R
+++ b/R/plot_group_numbers_old.R
@@ -17,7 +17,7 @@
 ## Usage ----
 ##
 ## $ Rscript getGenesetAnnotations.R
-##           --table=grouping.factors.txt
+##           --table=grouping.factors.tsv
 ##           --seuratobject=seurat.Robj
 ##           --groupfactors=cluster
 ##           --subgroupfactors=patient
@@ -151,7 +151,7 @@ for(group_var in group_vars)
 
         # save the plot data.
         write.table(plot_data,
-                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
+                    file.path(opt$outdir,paste0(plotfilename,".plotdata.tsv")),
                     col.names=TRUE,
                     row.names=FALSE,
                     quote=FALSE,
@@ -232,7 +232,7 @@ for(group_var in group_vars)
 
         # save the plot data.
         write.table(plot_data,
-                    file.path(opt$outdir,paste0(plotfilename,".plotdata.txt")),
+                    file.path(opt$outdir,paste0(plotfilename,".plotdata.tsv")),
                     col.names=TRUE,
                     row.names=FALSE,
                     quote=FALSE,

--- a/R/plot_rdims_cluster_genes.R
+++ b/R/plot_rdims_cluster_genes.R
@@ -108,6 +108,8 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
+if(opt$pointpch != ".") { opt$pointpch <- as.numeric(opt$pointpch) }
+
 cat("Running with options:\n")
 print(opt)
 
@@ -116,7 +118,7 @@ print(opt)
 #data <- read.table(opt$assaydata, sep="\t", header=T, as.is=T, check.names=F)
 message("reading in assay data")
 data <- readRDS(opt$assaydata)
-##
+
 message("reading in the coordinates")
 plot_data <- read.table(opt$table,sep="\t",header=TRUE)
 

--- a/R/plot_rdims_factor.R
+++ b/R/plot_rdims_factor.R
@@ -125,11 +125,23 @@ if(opt$metadata!="none")
 }
 
 if ("cluster" %in% colnames(plot_data)){
-  plot_data$cluster <- factor(plot_data$cluster, levels=sort(as.numeric(unique(plot_data$cluster))))
+    cluster_col = "cluster"
+} else if ("cluster_id" %in% colnames(plot_data))
+{
+    cluster_col = "cluster_id"
+} else
+{
+    cluster_col = NULL
 }
 
 
+if(!is.null(cluster_col))
+{
+  plot_data[[cluster_col]] <- factor(plot_data[[cluster_col]], levels=sort(as.numeric(unique(plot_data[[cluster_col]]))))
+}
+
 color_vars <- strsplit(opt$colorfactors,",")[[1]]
+print(color_vars)
 tex = ""
 
 print("Making tSNE plots colored by each of the factor variables")
@@ -139,9 +151,9 @@ for(color_var in color_vars)
     print(paste("Making",color_var,"tSNE plot"))
 
 
-    if(color_var=="cluster")
+    if(color_var==cluster_col)
     {
-        clust_levels = unique(plot_data$cluster)
+        clust_levels = unique(plot_data[[cluster_col]])
 
         print(head(plot_data))
         message("computing cluster centers")
@@ -152,8 +164,8 @@ for(color_var in color_vars)
         print(head(centers))
         for(clust in clust_levels)
         {
-            centers[clust,"x"] = median(plot_data[plot_data$cluster==clust,opt$rdim1])
-            centers[clust,"y"] = median(plot_data[plot_data$cluster==clust,opt$rdim2])
+            centers[clust,"x"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim1])
+            centers[clust,"y"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim2])
         }
         message("computed cluster centers")
         print(head(centers))
@@ -167,7 +179,7 @@ for(color_var in color_vars)
     if(is.numeric(plot_data[[color_var]]))
     {
         if((all(plot_data[[color_var]] == round(plot_data[[color_var]]))
-           & length(unique(plot_data[[color_var]])) < 50) || color_var == "cluster")
+           & length(unique(plot_data[[color_var]])) < 50) || color_var == cluster_col)
         {
             plot_data[[color_var]] <- as.character(plot_data[[color_var]])
         }
@@ -199,7 +211,7 @@ for(color_var in color_vars)
     }
 
 
-    if(color_var == "cluster")
+    if(color_var == cluster_col)
     {
         gp <- gp + geom_text(data=centers, aes(x, y, label=cluster), color="black")
     }

--- a/R/plot_rdims_factor.R
+++ b/R/plot_rdims_factor.R
@@ -110,6 +110,7 @@ if(opt$metadata!="none")
     meta_data <- read.table(opt$metadata, sep="\t", header=TRUE)
     rownames(meta_data) <- meta_data$barcode
     meta_data$barcode <- NULL
+    meta_cols <- colnames(meta_data)
 
     if(length(intersect(rownames(plot_data), rownames(meta_data))) < length(rownames(meta_data)))
     {
@@ -117,7 +118,9 @@ if(opt$metadata!="none")
     } else {
 
         meta_data <- meta_data[rownames(plot_data),]
+        plot_cols <- colnames(plot_data)
         plot_data <- cbind(plot_data, meta_data)
+        colnames(plot_data) <- c(plot_cols, meta_cols)
     }
 }
 

--- a/R/plot_rdims_factor.R
+++ b/R/plot_rdims_factor.R
@@ -96,6 +96,8 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
+if(opt$pointpch != ".") { opt$pointpch <- as.numeric(opt$pointpch) }
+
 cat("Running with options:\n")
 print(opt)
 
@@ -131,13 +133,14 @@ if ("cluster" %in% colnames(plot_data)){
     cluster_col = "cluster_id"
 } else
 {
-    cluster_col = NULL
+    cluster_col = "__none__"
 }
 
 
-if(!is.null(cluster_col))
+if(!cluster_col=="__none__")
 {
-  plot_data[[cluster_col]] <- factor(plot_data[[cluster_col]], levels=sort(as.numeric(unique(plot_data[[cluster_col]]))))
+    plot_data[[cluster_col]] <- factor(plot_data[[cluster_col]],
+                                       levels=sort(as.numeric(unique(plot_data[[cluster_col]]))))
 }
 
 color_vars <- strsplit(opt$colorfactors,",")[[1]]
@@ -148,29 +151,29 @@ print("Making tSNE plots colored by each of the factor variables")
 ## Make one whole-page tSNE plot per color variable
 for(color_var in color_vars)
 {
-    print(paste("Making",color_var,"tSNE plot"))
-
+    print(paste("Making",color_var,"rdims plot"))
 
     if(color_var==cluster_col)
     {
-        clust_levels = unique(plot_data[[cluster_col]])
+                clust_levels = unique(plot_data[[cluster_col]])
 
-        print(head(plot_data))
-        message("computing cluster centers")
-        centers = data.frame(row.names=clust_levels, "cluster"=clust_levels,
-                             "x"=1,
-                             "y"=1)
+                print(head(plot_data))
+                message("computing cluster centers")
+                centers = data.frame(row.names=clust_levels, "cluster"=clust_levels,
+                                     "x"=1,
+                                     "y"=1)
 
-        print(head(centers))
-        for(clust in clust_levels)
-        {
-            centers[clust,"x"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim1])
-            centers[clust,"y"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim2])
+                print(head(centers))
+                for(clust in clust_levels)
+                {
+                    centers[clust,"x"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim1])
+                    centers[clust,"y"] = median(plot_data[plot_data[[cluster_col]]==clust,opt$rdim2])
+                }
+                message("computed cluster centers")
+                print(head(centers))
+
+
         }
-        message("computed cluster centers")
-        print(head(centers))
-
-    }
 
 
     ## If a variable comprises only integers, coerce it to a character vector
@@ -236,9 +239,8 @@ for(color_var in color_vars)
 
 
 
-
     ## write out a separate legend if we have more than 20 levels.
-
+    gp <- gp + theme_minimal()
 
 
     plotfilename = paste(opt$method, color_var, sep=".")

--- a/R/plot_rdims_gene.R
+++ b/R/plot_rdims_gene.R
@@ -114,6 +114,8 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
+if(opt$pointpch != ".") { opt$pointpch <- as.numeric(opt$pointpch) }
+
 cat("Running with options:\n")
 print(opt)
 
@@ -170,7 +172,7 @@ genes$plot_name <- plot_names
 rownames(genes) <- genes[[id_col]]
 
 ## get the geneset name
-geneset <- gsub(".txt", "", basename(opt$genetable))
+geneset <- gsub(".tsv", "", basename(opt$genetable))
 geneset <- gsub(".csv", "", geneset)
 
 ## initialise the tex snippet

--- a/R/scanpy_post_process_clusters.R
+++ b/R/scanpy_post_process_clusters.R
@@ -1,0 +1,87 @@
+## Cluster the single cells in a given Seurat object
+
+# Libraries ----
+
+stopifnot(
+  require(optparse),
+  require(Seurat),
+  require(dplyr),
+  require(Matrix),
+  require(reshape2),
+  require(tenxutils),
+  require(xtable)
+)
+
+# Options ----
+
+option_list <- list(
+    make_option(c("--seuratobject"), default="begin.Robj",
+                help="A seurat object after PCA"),
+    make_option(c("--clusters"), default="scanpy.clusters.tsv.gz",
+                help="the scanpy cluster assignments"),
+    make_option(c("--algorithm"), default="leiden",
+                help="name of the clustering alogorithm"),
+    make_option(c("--mincells"), type="integer", default=10,
+                help="clusters with fewer cells are set to NA"),
+    make_option(c("--outdir"), default="seurat.out.dir",
+                help="outdir")
+    )
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+cat("Running with options:\n")
+print(opt)
+
+message(sprintf("readRDS: %s", opt$seuratobject))
+s <- readRDS(opt$seuratobject)
+
+
+message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
+
+clusters <- read.table(opt$clusters, sep="\t", header=T, as.is=T)
+
+cluster_ids <- clusters[[opt$algorithm]]
+
+if(!all(names(cluster_ids)==Cells(s)))
+{    stop("barcodes from scanpy do not match cells from seurat") }
+
+print(table(cluster_ids))
+
+x <- table(cluster_ids)
+
+rejected_clusters <- names(x[x<opt$mincells])
+cluster_ids[cluster_ids %in% rejected_clusters] <- "911"
+
+cluster_ids <- factor(as.numeric(cluster_ids))
+names(cluster_ids) <- clusters$barcode
+
+print(head(cluster_ids))
+print(table(cluster_ids))
+
+unique_cluster_ids <- unique(cluster_ids)
+
+print(unique_cluster_ids)
+
+message(sprintf("saving a unique list ofe cluster ids"))
+write.table(unique_cluster_ids, file=file.path(opt$outdir,"cluster_ids.tsv"),
+            quote=FALSE, col.names = FALSE, row.names = FALSE)
+
+cluster_colors <- gg_color_hue(length(unique_cluster_ids))
+message(sprintf("saving the cluster colors (ggplot)"))
+write.table(cluster_colors, file=file.path(opt$outdir,"cluster_colors.tsv"),
+            quote=FALSE, col.names = FALSE, row.names = FALSE)
+
+message(sprintf("saveRDS"))
+saveRDS(cluster_ids, file=file.path(opt$outdir,"cluster_ids.rds"))
+
+cluster_assignments <- data.frame(barcode=as.character(names(cluster_ids)),
+                                  cluster_id=as.character(cluster_ids))
+
+write.table(cluster_assignments,
+            gzfile(file.path(opt$outdir, "cluster_assignments.tsv.gz")),
+            sep="\t", col.names=T, row.names=F, quote=F)
+
+
+message("seurat_cluster.R final default assay: ", DefaultAssay(s))
+
+message("Completed")

--- a/R/seurat_FindMarkers.R
+++ b/R/seurat_FindMarkers.R
@@ -329,7 +329,7 @@ for (conserved.level in levels(ident.conserved)){
         }
 
         ## write out the full results
-        ## file name should be markers.cluster.x.txt
+        ## file name should be markers.cluster.x.tsv
 
         if(opt$testfactor=="none"){
             if (opt$conservedfactor == "none"){
@@ -348,7 +348,7 @@ for (conserved.level in levels(ident.conserved)){
 
         out_path <- file.path(
             opt$outdir,
-            paste(prefix,opt$cluster,"txt","gz",sep="."))
+            paste(prefix,opt$cluster,"tsv","gz",sep="."))
 
         print(paste("Saving markers to:", out_path))
 
@@ -383,7 +383,7 @@ for (conserved.level in levels(ident.conserved)){
 
         universe_path <- file.path(
             opt$outdir,
-            paste(prefix,opt$cluster,"universe","txt","gz",sep="."))
+            paste(prefix,opt$cluster,"universe","tsv","gz",sep="."))
 
         write.table(universe,
                     gzfile(universe_path),
@@ -554,7 +554,7 @@ if (length(markers.conserved.list) > 1){
 
     out_path <- file.path(
             opt$outdir,
-            paste(prefix,opt$cluster,"txt","gz",sep="."))
+            paste(prefix,opt$cluster,"tsv","gz",sep="."))
 
     print(paste("Saving markers to:", out_path))
 
@@ -597,7 +597,7 @@ if (length(markers.conserved.list) > 1){
 
     universe_path <- file.path(
         opt$outdir,
-        paste(prefix,opt$cluster,"universe","txt","gz",sep="."))
+        paste(prefix,opt$cluster,"universe","tsv","gz",sep="."))
 
     write.table(universe,
                 gzfile(universe_path),

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -369,7 +369,7 @@ if(opt$matrixtype=="10X")
     rownames(genes) <- genes$seurat_id
 
     write.table(
-        genes, file.path(opt$outdir, "annotation.txt"),
+        genes, file.path(opt$outdir, "annotation.tsv"),
         sep="\t", col.names=TRUE, row.names=FALSE, quote=FALSE
     )
 

--- a/R/seurat_characteriseClusterDEGenes.R
+++ b/R/seurat_characteriseClusterDEGenes.R
@@ -49,6 +49,12 @@ option_list <- list(
                 help="latex var containing location of the plots"),
     make_option(c("--useminfc"), default=FALSE,
                 help="Use minimum fold change for second page of violin plots"),
+    make_option(c("--ncol"), type="integer", default=4,
+                help="Number of columns for the plots"),
+        make_option(c("--nrow"), type="integer", default=4,
+                help="Number of rows for the plots"),
+    make_option(c("--pointsize"), type="integer", default=FALSE,
+                help="pointsize for the violin plots"),
     make_option(c("--pdf"), default=FALSE,
                 help="Produce pdf plots"),
     make_option(c("--outdir"), default="seurat.out.dir",
@@ -188,7 +194,7 @@ if(opt$useminfc)
     fc_type="fold change"
 }
 
-ncol = 4
+ncol = opt$ncol
 
 if(is.null(opt$testfactor))
 {
@@ -203,7 +209,8 @@ if(is.null(opt$testfactor))
 message("making violin plots for +ve genes")
 pos_tex <- violinPlotSection(violin_data, s, cluster_ids, type="positive",
                              group.by = opt$testfactor,
-                             ident.include = ident.include, ncol=ncol,
+                             ident.include = ident.include, vncol=opt$ncol, vnrow=opt$nrow,
+                             pt_size=opt$pointsize,
                              outdir = opt$outdir,
                              analysis_title = analysis_title, fc_type = fc_type,
                              use.minfc = opt$useminfc,
@@ -214,7 +221,8 @@ pos_tex <- violinPlotSection(violin_data, s, cluster_ids, type="positive",
 message("making violin plots for -ve genes")
 neg_tex <- violinPlotSection(violin_data, s, cluster_ids, type="negative",
                              group.by = opt$testfactor,
-                             ident.include = ident.include, ncol=ncol,
+                             ident.include = ident.include, vncol=opt$ncol, vnrow=opt$nrow,
+                             pt_size=opt$pointsize,
                              outdir = opt$outdir,
                              analysis_title = analysis_title, fc_type = fc_type,
                              use.minfc = opt$useminfc,

--- a/R/seurat_characteriseClusterDEGenes.R
+++ b/R/seurat_characteriseClusterDEGenes.R
@@ -89,23 +89,11 @@ if(is.null(opt$testfactor))
 tex = ""
 
 ## read in the de genes
-degenes <- read.table(gzfile(opt$degenes),header=T,as.is=T,sep="\t")
-
-## read in the seurat object
-s <- readRDS(opt$seuratobject)
-cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
-
-## set the default assay
-message("Setting default assay to: ", opt$seuratassay)
-DefaultAssay(s) <- opt$seuratassay
-
-message("seurat_characteriseClusterDEGenes.R running with default assay: ", DefaultAssay(s))
-
 
 cluster <- opt$cluster
+data <- read.table(gzfile(opt$degenes),header=T,as.is=T,sep="\t")
 
-if(!cluster %in% degenes$cluster)
+if(!cluster %in% data$cluster)
 {
     ## we have no DE genes.
     message("No significant genes for cluster: ",cluster)
@@ -113,7 +101,8 @@ if(!cluster %in% degenes$cluster)
 
 {
 
-decluster <- degenes[degenes$cluster == cluster,]
+data <- data[data$cluster == cluster,]
+
 
 message("processing cluster: ",cluster)
 
@@ -121,7 +110,7 @@ message("making scatter plots")
 ## analyse expression level vs fold change
 ## note that we intentionally ignore the pseudocount that seurat has added.
 
-data <- decluster
+#data <- decluster
 print(head(data))
 
 data$M <- log2( exp(data[[a]]) / exp(data[[b]]) )
@@ -130,8 +119,11 @@ data$A <- 1/2 * (log2(exp(data[[a]])) + log2(exp(data[[b]])))
 ma <- plotMA(data,xlab="expression level (log2)",ylab="fold change (log2)")
 vol <- plotVolcano(data,xlab="fold change (log2)",ylab="adjusted p-value (-log10)")
 
+data$M <- NULL
+data$A <- NULL
+
 ## analyse percentage vs change in percentage
-data <- decluster
+#data <- decluster
 
 data$M <- log2((data$pct.1*100 + 1) / (data$pct.2*100 + 1))
 data$A <- 1/2 * (log2(data$pct.1*100 + 1) + log2(data$pct.2*100 + 1))
@@ -139,20 +131,29 @@ data$A <- 1/2 * (log2(data$pct.1*100 + 1) + log2(data$pct.2*100 + 1))
 pma <- plotMA(data,xlab="percent cells (log2)",ylab="percent change (log2)")
 pvol <- plotVolcano(data,xlab="percent change (log2)",ylab="adjusted p-value (-log10)")
 
+data$M <- NULL
+data$A <- NULL
+
 ## directly compare fold change and percentage change
-data <- decluster
+#data <- decluster
 data$L <- log2((data$pct.1*100 + 1) / (data$pct.2*100 + 1))
 data$M <- log2(exp(data[[a]]) / exp(data[[b]]))
 
 fve <- plotFvE(data)
+
+data$M <- NULL
+data$L <- NULL
 
 ## sneakily extract the legend...
 legend <- g_legend(fve)
 fve <- fve + theme(legend.position = 'none')
 
 gs <- list(ma, vol, pma, pvol, fve, legend)
+rm(ma, vol, pma, pvol, fve, legend)
+
 lay <- rbind(c(1,2),c(3,4),c(5,6))
 ga <- arrangeGrob(grobs = gs, layout_matrix = lay)
+rm(gs)
 
 defn <- paste(c("dePlots",cluster,file_suffix),collapse=".")
 defpath <- file.path(opt$outdir, defn)
@@ -162,6 +163,9 @@ save_ggplots(defpath,
              to_pdf=opt$pdf,
              width=8,
              height=10)
+
+rm(ga)
+gc()
 
 ## start building figure latex...
 subsectionTitle <- getSubsectionTex(paste0("Cluster ",cluster,": summary plots"))
@@ -182,10 +186,22 @@ tex <- c(tex, getFigureTex(defn, deCaption,plot_dir_var=opt$plotdirvar))
 ## order by should be one of "p-value", "fold-change" or "min-fold-change".
 ## enforce significance
 
+## read in the seurat object
+s <- readRDS(opt$seuratobject)
+cluster_ids <- readRDS(opt$clusterids)
+Idents(s) <- cluster_ids
+
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("seurat_characteriseClusterDEGenes.R running with default assay: ", DefaultAssay(s))
+
 violin_fn_template <- paste(c("violinPlots.type",cluster,file_suffix),collapse=".")
 
-violin_data <- decluster[decluster$p.adj < 0.05,]
-print(dim(violin_data))
+data <- data[data$p.adj < 0.05,]
+
+print(dim(data))
 
 if(opt$useminfc)
 {
@@ -207,7 +223,7 @@ if(is.null(opt$testfactor))
 
 ## make the +ve plots
 message("making violin plots for +ve genes")
-pos_tex <- violinPlotSection(violin_data, s, cluster_ids, type="positive",
+pos_tex <- violinPlotSection(data, s, cluster_ids, type="positive",
                              group.by = opt$testfactor,
                              ident.include = ident.include, vncol=opt$ncol, vnrow=opt$nrow,
                              pt_size=opt$pointsize,
@@ -219,7 +235,7 @@ pos_tex <- violinPlotSection(violin_data, s, cluster_ids, type="positive",
 
 ## make the -ve plots
 message("making violin plots for -ve genes")
-neg_tex <- violinPlotSection(violin_data, s, cluster_ids, type="negative",
+neg_tex <- violinPlotSection(data, s, cluster_ids, type="negative",
                              group.by = opt$testfactor,
                              ident.include = ident.include, vncol=opt$ncol, vnrow=opt$nrow,
                              pt_size=opt$pointsize,

--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -17,14 +17,15 @@ stopifnot(
 option_list <- list(
     make_option(c("--seuratobject"), default="begin.Robj",
                 help="A seurat object after PCA"),
-    make_option(c("--usesigcomponents"), default=FALSE,
-                help="use significant principle component"),
-    make_option(c("--components"), type="integer", default=10,
-                help="if usesigcomponents is FALSE, the number of principle components to use"),
+    make_option(c("--seuratgraphs"), default="begin.Robj",
+                help="An rds object containing the seurat nn and snn graphs"),
+
+    ## make_option(c("--usesigcomponents"), default=FALSE,
+    ##             help="use significant principle component"),
+    ## make_option(c("--components"), type="integer", default=10,
+    ##             help="if usesigcomponents is FALSE, the number of principle components to use"),
     make_option(c("--predefined"), default=NULL,
                 help="An rds file containing a named vector of predefined cell cluster assignments"),
-    make_option(c("--nneighbors"), type="integer", default=20L,
-                help="number of neighbors (k.param)"),
     make_option(c("--resolution"), type="double", default=1,
                 help="cluster resolution"),
     make_option(c("--algorithm"), type="integer", default=3,
@@ -32,9 +33,7 @@ option_list <- list(
     make_option(c("--project"), default="SeuratAnalysis",
                 help="project name"),
     make_option(c("--outdir"), default="seurat.out.dir",
-                help="outdir"),
-    make_option(c("--reductiontype"), default="pca",
-                help="Name of dimensional reduction technique to use in construction of SNN graph. (e.g. 'pca', 'ica')")
+                help="outdir")
     )
 
 opt <- parse_args(OptionParser(option_list=option_list))
@@ -44,7 +43,7 @@ print(opt)
 
 message(sprintf("readRDS: %s", opt$seuratobject))
 s <- readRDS(opt$seuratobject)
-
+s@graphs <- readRDS(opt$seuratgraphs)
 
 message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
 
@@ -55,35 +54,35 @@ message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
 ## good results for single cell datasets of around 3K cells. Optimal resolution
 ## often increases for larger datasets. The clusters are saved in the object\@ident slot.
 
-if(opt$usesigcomponents)
-{
-    comps <- getSigPC(s)
-    message("using the following pcas:")
-    print(comps)
-} else {
-    comps <- 1:as.numeric(opt$components)
-}
+## if(opt$usesigcomponents)
+## {
+##     comps <- getSigPC(s)
+##     message("using the following pcas:")
+##     print(comps)
+## } else {
+##     comps <- 1:as.numeric(opt$components)
+## }
 
-if(toupper(opt$reductiontype)=="PCA")
-{ if(nrow(s@reductions$pca@jackstraw@overall.p.values) > 0)
-  {
-    ## Make a table of the retained principle components
-    x <- as.data.frame(s@reductions$pca@jackstraw@overall.p.values)
-    x$p.adj <- p.adjust(x$Score, method="BH")
-    x$significant <- "no"
-    x$significant[x$p.adj < 0.05] <- "yes"
-    x <- x[x$PC %in% comps,]
-    x$sdev <- s@reductions$pca@stdev[x$PC]
+## if(toupper(opt$reductiontype)=="PCA")
+## { if(nrow(s@reductions$pca@jackstraw@overall.p.values) > 0)
+##   {
+##     ## Make a table of the retained principle components
+##     x <- as.data.frame(s@reductions$pca@jackstraw@overall.p.values)
+##     x$p.adj <- p.adjust(x$Score, method="BH")
+##     x$significant <- "no"
+##     x$significant[x$p.adj < 0.05] <- "yes"
+##     x <- x[x$PC %in% comps,]
+##     x$sdev <- s@reductions$pca@stdev[x$PC]
 
-    print(
-        xtable(sprintfResults(x), caption=paste("Table of the selected (n=",
-                                                nrow(x),
-                                                ") principle components",
-                                                sep="")),
-        file=file.path(opt$outdir, "selected.principal.components.tex")
-    )
-  }
-}
+##     print(
+##         xtable(sprintfResults(x), caption=paste("Table of the selected (n=",
+##                                                 nrow(x),
+##                                                 ") principle components",
+##                                                 sep="")),
+##         file=file.path(opt$outdir, "selected.principal.components.tex")
+##     )
+##   }
+## }
 
 
 if(is.null(opt$predefined))
@@ -91,10 +90,6 @@ if(is.null(opt$predefined))
 
 
     message(sprintf("FindClusters"))
-    s <- FindNeighbors(s,
-                       reduction = opt$reductiontype,
-                       k.param = opt$nneighbors,
-                       dims = comps)
 
 
     s <- FindClusters(s,
@@ -139,7 +134,7 @@ write.table(cluster_colors, file=file.path(opt$outdir,"cluster_colors.txt"),
 message(sprintf("saveRDS"))
 saveRDS(cluster_ids, file=file.path(opt$outdir,"cluster_ids.rds"))
 
-cluster_assignments <- data.frame(barcodes=as.character(names(cluster_ids)),
+cluster_assignments <- data.frame(barcode=as.character(names(cluster_ids)),
                                   cluster_id=as.character(cluster_ids))
 
 write.table(cluster_assignments,

--- a/R/seurat_cluster.R
+++ b/R/seurat_cluster.R
@@ -123,12 +123,12 @@ if(is.null(opt$predefined))
 unique_cluster_ids <- sort(unique(cluster_ids))
 
 message(sprintf("saving a unique list ofe cluster ids"))
-write.table(unique_cluster_ids, file=file.path(opt$outdir,"cluster_ids.txt"),
+write.table(unique_cluster_ids, file=file.path(opt$outdir,"cluster_ids.tsv"),
             quote=FALSE, col.names = FALSE, row.names = FALSE)
 
 cluster_colors <- gg_color_hue(length(unique_cluster_ids))
 message(sprintf("saving the cluster colors (ggplot)"))
-write.table(cluster_colors, file=file.path(opt$outdir,"cluster_colors.txt"),
+write.table(cluster_colors, file=file.path(opt$outdir,"cluster_colors.tsv"),
             quote=FALSE, col.names = FALSE, row.names = FALSE)
 
 message(sprintf("saveRDS"))
@@ -138,7 +138,7 @@ cluster_assignments <- data.frame(barcode=as.character(names(cluster_ids)),
                                   cluster_id=as.character(cluster_ids))
 
 write.table(cluster_assignments,
-            gzfile(file.path(opt$outdir, "cluster_assignments.txt.gz")),
+            gzfile(file.path(opt$outdir, "cluster_assignments.tsv.gz")),
             sep="\t", col.names=T, row.names=F, quote=F)
 
 

--- a/R/seurat_clusterStats.R
+++ b/R/seurat_clusterStats.R
@@ -200,7 +200,7 @@ if (length(stats.list) > 1){
 
 out_path <- file.path(
     opt$outdir,
-    paste("cluster.stats",opt$cluster,"txt","gz",sep="."))
+    paste("cluster.stats",opt$cluster,"tsv","gz",sep="."))
 
 print(paste("Saving markers to:", out_path))
 

--- a/R/seurat_compare_clusters.R
+++ b/R/seurat_compare_clusters.R
@@ -41,6 +41,8 @@ message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
 
 Idents(s) <- readRDS(opt$clusterids)
 
+print(Idents(s))
+
 ## Get the components
 if(opt$usesigcomponents)
 {

--- a/R/seurat_create_object.R
+++ b/R/seurat_create_object.R
@@ -374,7 +374,7 @@ if(opt$matrixtype=="10X")
     rownames(genes) <- genes$seurat_id
 
     write.table(
-        genes, file.path(opt$outdir, "annotation.txt"),
+        genes, file.path(opt$outdir, "annotation.tsv"),
         sep="\t", col.names=TRUE, row.names=FALSE, quote=FALSE
     )
 

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -37,7 +37,7 @@ option_list <- list(
                 help="Name of dimensional reduction technique to use for building the diffusion map. (e.g. 'pca', 'ica')"),
     make_option(c("--plotdirvar"), default="diffmapDir",
                 help="name of the latex var containing the directory with the plots"),
-    make_option(c("--outfile"), default="dm.txt",
+    make_option(c("--outfile"), default="dm.tsv",
                 help="the file to which the diffusion map coordinates will be written"),
     make_option(c("--outdir"), default="seurat.out.dir",
                 help="the directory in which plots will be saved")

--- a/R/seurat_find_neighbors.R
+++ b/R/seurat_find_neighbors.R
@@ -1,0 +1,141 @@
+## Title ----
+##
+## Initial steps of the Seurat workflow for single-cell RNA-seq analysis
+##
+## Description ----
+##
+## This script performs the initial steps of the Seurat (http://satijalab.org/seurat/)
+## workflow for single-cell RNA-seq analysis, including:
+## (i) Reading in the data
+## (ii) subsetting
+## (iii) QC filtering
+## (iv) Normalisation and removal of unwanted variation
+## (v) Identification of variable genes
+## (vi) Dimension reduction (PCA)
+##
+## The seurat object is saved as the R object "rds" in the output directory
+
+# Libraries ----
+
+stopifnot(
+  require(optparse),
+  require(Seurat),
+  require(sctransform),
+  require(ggplot2),
+  require(dplyr),
+  require(Matrix),
+  require(xtable),
+  require(tenxutils),
+  require(reshape2),
+  require(future)
+)
+
+
+# Options ----
+
+option_list <- list(
+    make_option(
+        c("--seuratobject"),
+        default="none",
+        help=paste("rds file containing the seurat object")
+        ),
+    make_option(
+        c("--outdir"),
+        default="seurat.out.dir",
+        help="Location for outputs files. Must exist."
+    ),
+    make_option(c("--usesigcomponents"), default=FALSE,
+                help="use significant principle component"),
+    make_option(c("--components"), type="integer", default=10,
+                help="if usesigcomponents is FALSE, the number of principle components to use"),
+    make_option(c("--reductiontype"), default="pca",
+                help="Name of dimensional reduction technique to use in construction of SNN graph. (e.g. 'pca', 'ica')"),
+    make_option(c("--nneighbors"), type="integer", default=20L,
+                help="number of neighbors (k.param)"),
+    make_option(
+        c("--numcores"),
+        type="integer",
+        default=12,
+        help="Number of cores to be used for the Jackstraw analysis"
+    ),
+    make_option(
+        c("--memory"),
+        type="integer",
+        default=4000,
+        help="Amount of memory (mb) to request"
+    ),
+    make_option(
+        c("--plotdirvar"),
+        default="sampleDir",
+        help="latex var containig plot location"
+    )
+
+
+    )
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+cat("Running with options:\n")
+print(opt)
+
+plan("multiprocess",
+     workers = opt$numcores)
+
+#plan("sequential")
+
+options(future.globals.maxSize = opt$memory * 1024^2)
+
+# Input data ----
+
+s <- readRDS(opt$seuratobject)
+
+if(opt$usesigcomponents)
+{
+    comps <- getSigPC(s)
+    message("using the following pcas:")
+    print(comps)
+} else {
+    comps <- 1:as.numeric(opt$components)
+}
+
+
+
+if(toupper(opt$reductiontype)=="PCA")
+{ if(nrow(s@reductions$pca@jackstraw@overall.p.values) > 0)
+  {
+    ## Make a table of the retained principle components
+    x <- as.data.frame(s@reductions$pca@jackstraw@overall.p.values)
+    x$p.adj <- p.adjust(x$Score, method="BH")
+    x$significant <- "no"
+    x$significant[x$p.adj < 0.05] <- "yes"
+    x <- x[x$PC %in% comps,]
+    x$sdev <- s@reductions$pca@stdev[x$PC]
+
+    print(
+        xtable(sprintfResults(x), caption=paste("Table of the selected (n=",
+                                                nrow(x),
+                                                ") principle components",
+                                                sep="")),
+        file=file.path(opt$outdir, "selected.principal.components.tex")
+    )
+  }
+}
+
+message("Making the graphs")
+
+#
+
+s <- FindNeighbors(s,
+                   reduction = opt$reductiontype,
+                   k.param = opt$nneighbors,
+                   dims = comps)
+
+
+message("Finished making the graphs")
+
+message("seurat_begin.R object final default assay: ", DefaultAssay(s))
+
+# Save the graphs
+saveRDS(s@graphs, file=file.path(opt$outdir, "graphs.rds"))
+
+message("Completed")

--- a/R/seurat_get_assay_data.R
+++ b/R/seurat_get_assay_data.R
@@ -1,0 +1,91 @@
+## Title ----
+##
+## Visualise gene expression levels on reduced dimensions plots
+##
+## Description ----
+##
+## This script visualises per-cell gene expression levels on a 2D
+## reduced dimensions plot.
+##
+## Details ----
+##
+## Expression levels are taken from the "data" slot,
+## and truncated at the 95th expression percentile
+##
+## Usage ----
+##
+## See options.
+
+# Libraries ----
+
+stopifnot(
+  require(optparse),
+  require(ggplot2),
+  require(reshape2),
+  require(Seurat),
+  require(tenxutils),
+  require(BiocParallel),
+  require(Matrix)
+)
+
+# Options ----
+
+option_list <- list(
+    make_option(
+      c("--features"),
+      default="none",
+      help="A tab-delimited text file containing gene_id (or gene if s@misc$gene_id is not set) and gene_name"
+      ),
+    make_option(
+      c("--seuratobject"),
+      default="none",
+      help="The seurat object (e.g. begin.rds)"
+    ),
+    make_option(
+      c("--seuratassay"),
+      default="RNA",
+      help="The seurat assay to pull the expression data from"
+    ),
+    make_option(
+      c("--slot"),
+      default="None",
+      help="The name of the slot to pull the data from"
+      ),
+    make_option(
+      c("--outfile"),
+      default="assay.data.tsv.gz",
+      help="the file to write the data to")
+    )
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+cat("Running with options:\n")
+print(opt)
+
+
+## read in the raw count matrix
+s <- readRDS(opt$seuratobject)
+
+## set the default assay
+message("Setting default assay to: ", opt$seuratassay)
+DefaultAssay(s) <- opt$seuratassay
+
+message("plot_rdims_gene.R running with default assay: ", DefaultAssay(s))
+data <- GetAssayData(object = s, slot = opt$slot)  #data!
+
+# remove the Seurat object
+rm(s)
+
+## read in the table containing the genes to visualise
+features <- read.table(opt$features,
+                       header=TRUE,
+                       sep="\t",
+                       as.is=TRUE)
+
+## subset the gene expression matrix
+exprs <- as.matrix(data[features$gene,, drop=F])
+
+saveRDS(exprs, opt$outfile)
+#write.table(exprs, gzfile(opt$outfile), sep="\t", col.names=T, quote=F)
+
+message("completed")

--- a/R/seurat_summariseMarkers.R
+++ b/R/seurat_summariseMarkers.R
@@ -65,7 +65,7 @@ for (i in 1:length(idents.all)) {
 
     id <- idents.all[i]
 
-    tableName = paste("markers.cluster",id,"txt","gz",
+    tableName = paste("markers.cluster",id,"tsv","gz",
                       sep=".")
 
     markerFile <- file.path(opt$outdir,tableName)
@@ -197,11 +197,11 @@ take_cols <- c("min_logFC","max_logFC")
 markers[filtered_markers$index, take_cols] <- filtered_markers[,take_cols,with=F]
 
 ## write out the full (unannotated) table of significantly
-## differentially expressed marker genes as a txt file.
+## differentially expressed marker genes as a.tsv file.
 
-message("Saving marker.summary.table.txt")
+message("Saving marker.summary.table.tsv")
 
-marker_file <- paste(outPrefix,"table","txt","gz",
+marker_file <- paste(outPrefix,"table","tsv","gz",
                      sep=".")
 
 write.table(markers,
@@ -273,7 +273,7 @@ colnames(sumdf) <-c("cluster","ncells","n_pos_markers","n_neg_markers","n_marker
 
 print("Writing out some summary statistics")
 write.table(sumdf,
-            paste(outPrefix,"stats","txt",
+            paste(outPrefix,"stats","tsv",
                   sep="."),
             quote=F,sep="\t",row.names=F)
 

--- a/R/seurat_summariseMarkersBetween.R
+++ b/R/seurat_summariseMarkersBetween.R
@@ -91,7 +91,7 @@ for(cluster in clusters)
         opt$outdir,
         paste("markers.between",opt$testfactor,
               "cluster",cluster,
-              "txt","gz",
+              "tsv","gz",
               sep="."))
     message("res_fn:")
     print(res_fn)
@@ -132,12 +132,12 @@ res <- res[,c("cluster","gene","p.adj","p_val","avg_logFC",
 out_fn <- file.path(
     opt$outdir,
     paste("markers.between",opt$testfactor,
-          "summary.table.txt.gz",sep=".")
+          "summary.table.tsv.gz",sep=".")
 )
 
 ## write out the full table of differentially expressed genes.
-## in txt format
-message("Saving markers to txt file")
+## in.tsv format
+message("Saving markers to.tsv file")
 write.table(res, gzfile(out_fn), quote=F,
             row.names=F, col.names=T,
             sep="\t")
@@ -155,7 +155,7 @@ setColWidths(wb,"markers_between",cols=1:ncol(xres),widths=10)
 hs <- createStyle(textDecoration = "BOLD")
 writeData(wb, "markers_between", tidyNumbers(xres),
           withFilter = T, headerStyle=hs)
-saveWorkbook(wb, file=gsub(".txt.gz",".xlsx",out_fn),
+saveWorkbook(wb, file=gsub(".tsv.gz",".xlsx",out_fn),
              overwrite=T)
 
 

--- a/R/seurat_tsne.R
+++ b/R/seurat_tsne.R
@@ -35,7 +35,7 @@ option_list <- list(
                 help="project name"),
     make_option(c("--reductiontype"), default="pca",
                 help="Name of dimensional reduction technique to use in construction of SNN graph. (e.g. 'pca', 'ica', 'zinbwave', etc)"),
-    make_option(c("--outfile"), default="tsne.txt",
+    make_option(c("--outfile"), default="tsne.tsv",
                 help="the file to which the tSNE coordinates will be written")
     )
 

--- a/R/seurat_umap.R
+++ b/R/seurat_umap.R
@@ -15,10 +15,10 @@ stopifnot(
 # Options ----
 
 option_list <- list(
-    make_option(c("--seuratobject"), default="begin.Robj",
+    make_option(c("--seuratobject"), default="begin.rds",
                 help="A seurat object after PCA"),
-    make_option(c("--clusterids"), default="none",
-                help="A list object containing the cluster identities"),
+    make_option(c("--seuratgraphs"), default="graphs.rds",
+                help="the nn/snn graphs in an rds file"),
     make_option(c("--annotation"), default="none",
                 help="A file containing the mapping of gene_id, gene_name and seurat_id"),
     make_option(c("--method"), default="umap-learn",
@@ -53,8 +53,7 @@ print(opt)
 
 message("readRDS")
 s <- readRDS(opt$seuratobject)
-cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
+s@graphs <- readRDS(opt$seuratgraphs)
 
 message("seurat_umap.R running with default assay: ", DefaultAssay(s))
 
@@ -85,17 +84,11 @@ s <- RunUMAP(s,
 
 ## extract the UMAP coordinates from the seurat object
 umap <- as.data.frame(s@reductions$umap@cell.embeddings)
-umap$cluster <- Idents(s)[rownames(umap)]
 
-plot_data <- merge(umap, s[[]], by=0)
-
-rownames(plot_data) <- plot_data$Row.names
-plot_data$Row.names <- NULL
-
-plot_data$barcode <- row.names(plot_data)
+umap$barcode <- row.names(umap)
 
 ## save the annotated tSNE data frame
-write.table(plot_data, opt$outfile,
+write.table(umap, gzfile(opt$outfile),
             sep="\t", quote=FALSE, row.names=FALSE)
 
 message("seurat_umap.R final default assay: ", DefaultAssay(s))

--- a/R/seurat_umap.R
+++ b/R/seurat_umap.R
@@ -41,7 +41,7 @@ option_list <- list(
                 help="project name"),
     make_option(c("--reductiontype"), default="pca",
                 help="Name of dimensional reduction slot to use as the input to UMAP (e.g. 'pca', 'ica')"),
-    make_option(c("--outfile"), default="umap.txt",
+    make_option(c("--outfile"), default="umap.tsv",
                 help="the file to which the UMAP coordinates will be written")
     )
 

--- a/R/singleR_extra_plots.R
+++ b/R/singleR_extra_plots.R
@@ -225,14 +225,14 @@ cat("Saving output tables \n")
 pc_out <- df %>% dplyr::select(PC1, PC2, barcode)
 colnames(pc_out) <- c("singler_scores_pc1", "singler_scores_pc2", "barcode")
 top_scores <- left_join(top_scores, pc_out, by="barcode")
-write.table(top_scores, gzfile(paste0(opt$outdir, "/singler_predictions.txt.gz")),
+write.table(top_scores, gzfile(paste0(opt$outdir, "/singler_predictions.tsv.gz")),
             sep="\t", quote=FALSE, row.names=FALSE)
 
 # Output summary table
 t <- table(top_scores$pruned_label) %>% as.data.frame()
 colnames(t) <- c("label", "n")
 t <- t[order(t$n, decreasing = TRUE),]
-write.table(t,paste0(opt$outdir, "/singler_predictions_summary.txt"),
+write.table(t,paste0(opt$outdir, "/singler_predictions_summary.tsv"),
             sep="\t", quote=FALSE, row.names=FALSE)
 
 message("Completed\n\n")

--- a/R/summariseGenesets.R
+++ b/R/summariseGenesets.R
@@ -15,10 +15,8 @@ stopifnot(
 option_list <- list(
     make_option(c("--genesetdir"), default="none",
                 help="directory containing the genesets to aggregate"),
-    make_option(c("--nclusters"), type="integer", default=0,
-                help="the number of the clusters being analysed"),
-    make_option(c("--firstcluster"), type="integer", default=0,
-                help="clusters might not be zero based..."),
+    make_option(c("--clusters"), type="integer", default=0,
+                help="text file containing the cluster ids"),
     make_option(c("--pvaluethreshold"),type="double",default=0.05,
                 help="p value threshold for filtering sets"),
     make_option(c("--padjustmethod"), default="BH",
@@ -90,6 +88,9 @@ ltabs <- list()
 hmaps <- list()
 tex <- c()
 
+clusters <- as.numeric(read.table(opt$clusters, header=F)$V1)
+clusters <- clusters[order(clusters)]
+
 for(geneset in genesets)
 {
     genesets <- NULL
@@ -97,22 +98,22 @@ for(geneset in genesets)
     message(paste("Processing:", geneset,"annotations."))
     begin=T
 
-    if(opt$firstcluster==0)
-    {
-        first <- 0
-        last <- opt$nclusters - 1
-        }
-    else {
-            first <- opt$firstcluster
-            last <- opt$nclusters}
+    ## if(opt$firstcluster==0)
+    ## {
+    ##     first <- 0
+    ##     last <- opt$nclusters - 1
+    ##     }
+    ## else {
+    ##         first <- opt$firstcluster
+    ##         last <- opt$nclusters}
 
     ## build a single table containing the results of the geneset tests for
     ## all clusters
-    for(cluster in first:last)
+    for(cluster in clusters)
     {
         message(paste("Working on cluster: ", cluster))
 
-        fn = paste0(opt$genesetdir,"/",opt$prefix,".",cluster,".",geneset,".txt.gz")
+        fn = paste0(opt$genesetdir,"/",opt$prefix,".",cluster,".",geneset,".tsv.gz")
         if(file.exists(fn))
             {
                 temp = read.table(gzfile(fn),sep="\t",header=T,as.is=T,quote="")
@@ -257,7 +258,8 @@ for(geneset in genesets)
 
         if(!opt$showcommon)
         {
-           tmp <- table(xx$geneset_id)
+            tmp <- table(xx$geneset_id)
+            ## what is this? TODO: fix.
            xx <- xx[!xx$geneset_id %in% names(tmp)[tmp==opt$nclusters],]
         }
 
@@ -276,7 +278,7 @@ for(geneset in genesets)
         gp <- sampleEnrichmentDotplot(genesets,
                                       selected_genesets = genesets_to_show,
                                       selection_col = "geneset_id",
-                                      sample_levels =c(first:last),
+                                      sample_levels = clusters,
                                       min_dot_size =1, max_dot_size = 6,
                                       maxl = 45,
                                       pvalue_threshold = opt$pvaluethreshold,

--- a/R/summarise_clusterStats.R
+++ b/R/summarise_clusterStats.R
@@ -40,7 +40,7 @@ for (i in 1:length(idents.all)) {
 
     id <- idents.all[i]
 
-    tableName = paste("cluster.stats",id,"txt","gz",
+    tableName = paste("cluster.stats",id,"tsv","gz",
                       sep=".")
 
     markerFile <- file.path(opt$outdir,tableName)
@@ -78,7 +78,7 @@ for (i in 1:length(idents.all)) {
 
 stats.all$gene <- rownames(stats.all)
 
-out_path = file.path(opt$outdir, "cluster.stats.summary.table.txt.gz")
+out_path = file.path(opt$outdir, "cluster.stats.summary.table.tsv.gz")
 write.table(stats.all, gzfile(out_path),
             sep="\t", col.names=T, row.names=T, quote=F)
 

--- a/pipelines/pipeline_cellranger.py
+++ b/pipelines/pipeline_cellranger.py
@@ -92,7 +92,7 @@ $ cat data.dir/donor1_butyrate.1000.1.sample
 (B) If starting from the output of cellranger count:
 
 Two files are required:
-sample.information.txt: containing "sample_id", "agg_id" and "seq_id" coloumns/
+sample.information.tsv: containing "sample_id", "agg_id" and "seq_id" coloumns/
 cellranger.aggr.specification.csv: the specification file cellranger aggr.
 
 
@@ -319,7 +319,7 @@ def cellrangerCount(infile, outfile):
 @active_if(PARAMS["input"] == "mkfastq")
 @transform(cellrangerCount,
            regex(r"(.*)-count/cellranger.count.sentinel"),
-           r"\1-count/cellranger_metrics_summary.txt")
+           r"\1-count/cellranger_metrics_summary.tsv")
 def reformatCellrangerCountMetrics(infile, outfile):
     '''
     Parse the cellranger count summary metrics into a tabular format.
@@ -359,7 +359,7 @@ def loadCellrangerCountMetrics(infiles, outfile):
 
     P.concatenate_and_load(
         infiles, outfile,
-        regex_filename="(.*)-count/.*.txt",
+        regex_filename="(.*)-count/.*.tsv",
         has_titles=True,
         options="",
         cat="sample")
@@ -368,7 +368,7 @@ def loadCellrangerCountMetrics(infiles, outfile):
 @active_if(PARAMS["input"] == "mkfastq")
 @transform(cellrangerCount,
            regex(r"(.*)-count/cellranger.count.sentinel"),
-           r"\1-count/cellranger.raw.qc.txt")
+           r"\1-count/cellranger.raw.qc.tsv")
 def rawQcMetricsPerBarcode(infile, outfile):
     '''
     Compute the total UMI, rank, mitochondrial UMI for each barcode.
@@ -385,7 +385,7 @@ def rawQcMetricsPerBarcode(infile, outfile):
     gtf = os.path.join(transcriptome, "genes", "genes.gtf")
 
     # Build the path to the log file
-    log_file = P.snip(outfile, ".txt") + ".log"
+    log_file = P.snip(outfile, ".tsv") + ".log"
 
     statement = '''Rscript %(tenx_dir)s/R/cellranger_rawQcMetrics.R
                    --matrixpath=%(matrixpath)s
@@ -407,7 +407,7 @@ def loadRawQcMetricsPerBarcode(infiles, outfile):
 
     P.concatenate_and_load(
         infiles, outfile,
-        regex_filename="(.*)-count/.*.txt",
+        regex_filename="(.*)-count/.*.tsv",
         has_titles=True,
         options="",
         cat="sample")
@@ -498,7 +498,7 @@ PICARD_MEMORY = str(
 @active_if(PARAMS["input"] == "mkfastq")
 @transform(cellrangerCount,
            regex(r"(.*)-count/cellranger.count.sentinel"),
-           r"\1-count/picard_duplication_metrics.txt")
+           r"\1-count/picard_duplication_metrics.tsv")
 def picardMarkDuplicates(infile, outfile):
     '''
     Yield duplication metrics using Picard Tools.
@@ -553,7 +553,7 @@ def loadDuplicationMetrics(infiles, outfile):
 
     P.concatenate_and_load(
         infiles, outfile,
-        regex_filename="(.*)-count/.*.txt",
+        regex_filename="(.*)-count/.*.tsv",
         has_titles=True,
         options="",
         cat="sample")
@@ -588,7 +588,7 @@ def plotMetrics(infile, outfile):
 
 
 @follows(cellrangerCount)
-@files(None, "sample.information.txt")
+@files(None, "sample.information.tsv")
 def writeSampleInformation(infile, outfile):
     '''
     Write out the sample information table.
@@ -607,7 +607,7 @@ if PARAMS["input"] == "mkfastq":
     collectSampleInformation = writeSampleInformation
 
 elif PARAMS["input"] == "count":
-    collectSampleInformation = "sample.information.txt"
+    collectSampleInformation = "sample.information.tsv"
 
 else:
     raise ValueError('Input type must be either "mkfastq"'

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -888,7 +888,7 @@ def scanpyCluster(infile, outfile):
     spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
 
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_high"])
+        memory=PARAMS["resources_memory_low"])
 
     statement = '''python %(tenx_dir)s/python/run_cluster.py
                    --anndata=%(anndata)s
@@ -1449,7 +1449,7 @@ def plotRdimsFactors(infiles, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     statement = '''Rscript %(tenx_dir)s/R/plot_rdims_factor.R
                    --method=%(rdims_vis_method)s
@@ -1504,7 +1504,7 @@ def plotRdimsClusters(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     statement = '''Rscript %(tenx_dir)s/R/plot_rdims_factor.R
                    --method=%(rdims_vis_method)s
@@ -1803,6 +1803,9 @@ def plotGroupNumbers(infile, outfile):
 
         SPEC["log_file"] = os.path.join(spec.outdir, summary_key + ".log")
 
+        job_threads, job_memory, r_memory = TASK.get_resources(
+            memory=PARAMS["resources_memory_min"])
+
         statement = '''Rscript %(tenx_dir)s/R/plot_group_numbers.R
                    --metadata=%(metadata_table)s
                    --clusters=%(cluster_assignments)s
@@ -2026,7 +2029,7 @@ def summariseClusterStats(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_high"],
+        memory=PARAMS["resources_memory_min"],
         cpu=1)
 
     # make sumamary tables and plots of the differentially expressed genes
@@ -2065,7 +2068,7 @@ def summariseMarkers(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_high"],
+        memory=PARAMS["resources_memory_standard"],
         cpu=1)
 
     # make sumamary tables and plots of the differentially expressed genes
@@ -2107,7 +2110,7 @@ def characteriseClusterMarkers(infile, outfile):
     degenes = pd.read_csv(marker_table, sep="\t")
 
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"],
+        memory=PARAMS["resources_memory_low"],
         cpu=1)
 
     statements = []
@@ -2160,7 +2163,7 @@ def plotMarkerNumbers(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_low"])
+        memory=PARAMS["resources_memory_min"])
 
     statement = '''Rscript %(tenx_dir)s/R/seurat_summariseMarkerNumbers.R
                    --degenes=%(marker_table)s
@@ -2743,7 +2746,7 @@ def genesetAnalysis(infiles, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     for i in spec.clusters:
 
@@ -2806,7 +2809,7 @@ def summariseGenesetAnalysis(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     statement = '''Rscript %(tenx_dir)s/R/summariseGenesets.R
                          --genesetdir=%(genesetdir)s
@@ -2867,7 +2870,7 @@ def genesetAnalysisBetweenConditions(infiles, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     for i in spec.clusters:
 
@@ -2933,7 +2936,7 @@ def summariseGenesetAnalysisBetweenConditions(infile, outfile):
 
     # set the job threads and memory
     job_threads, job_memory, r_memory = TASK.get_resources(
-        memory=PARAMS["resources_memory_standard"])
+        memory=PARAMS["resources_memory_min"])
 
     statement = '''Rscript %(tenx_dir)s/R/summariseGenesets.R
                          --genesetdir=%(genesetdir)s

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -3287,8 +3287,8 @@ def summaryReport(infile, outfile):
 
 @follows(mkdir("reports.dir"), geneExpressionReport)
 @transform(summaryReport,
-           regex(r"(.*).seurat.dir/(.*)/latex.dir/summaryReport.pdf"),
-           r"reports.dir/\1.\2/export.sentinel")
+           regex(r"(.*).seurat.dir/components.(.*).dir/cluster.(.*).dir/latex.dir/summaryReport.pdf"),
+           r"reports.dir/\1.\2_\3/export.sentinel")
 def export(infile, outfile):
     '''
     Link output files to a directory in the "reports.dir" folder.

--- a/pipelines/pipeline_seurat/clustree.tex
+++ b/pipelines/pipeline_seurat/clustree.tex
@@ -3,7 +3,7 @@
 The \href{https://doi.org/10.1093/gigascience/giy083}{clustree algorithm} is used to compare the different clustering resolutions.
 
 \begin{figure}[H]
-\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\clusterDir/clustree}}}
+\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\compDir/clustree}}}
 \caption{The relationships between the clusters identified at different resolutions}
 \end{figure}
 

--- a/pipelines/pipeline_seurat/geneExpressionReport.tex
+++ b/pipelines/pipeline_seurat/geneExpressionReport.tex
@@ -69,11 +69,11 @@ Here, we aim to visualise the expression of the ``best'' cluster marker genes. T
 
 Up to \nPositiveMarkers{} top-scoring positive marker genes are shown for each cluster.
 
-\input{\clusterMarkerRdimsPlotsDir/plot.rdims.genes.top.positive.cluster.markers}
+\input{\clusterMarkerRdimsPlotsDir/top.positive.cluster.markers}
 
 \clearpage
 \subsection{Negative cluster marker genes}
 
 Up to \nNegativeMarkers{} top-scoring negative marker genes are shown for each cluster.
 
-\input{\clusterMarkerRdimsPlotsDir/plot.rdims.genes.top.negative.cluster.markers}
+\input{\clusterMarkerRdimsPlotsDir/top.negative.cluster.markers}

--- a/pipelines/pipeline_seurat/introReport.tex
+++ b/pipelines/pipeline_seurat/introReport.tex
@@ -15,7 +15,7 @@
 \vspace{10mm}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.6\textwidth,height=0.4\textheight,keepaspectratio]{{{\rdimsVisDir/\rdimsVisMethod.cluster}}}
+\includegraphics[width=0.6\textwidth,height=0.4\textheight,keepaspectratio]{{{\rdimsVisClusterDir/\rdimsVisMethod.cluster_id}}}
 \end{figure}
 
 \vspace{\fill}

--- a/pipelines/pipeline_seurat/introductionSection.tex
+++ b/pipelines/pipeline_seurat/introductionSection.tex
@@ -1,12 +1,23 @@
-The 10x data was analysed using the \href{http://satijalab.org/seurat/}{Seurat} package. The key parameter choices used for this analysis were:
+The core of the data analysis was performed using \href{http://satijalab.org/seurat/}{Seurat} and \href{https://scanpy.readthedocs.io/}{scanpy}:
+
+\begin{itemize}
+\item The construction of the nearest neighbor graph, clustering and UMAP computation were performed using scanpy.
+\item The differential expression analysis was performed using Seurat.
+\item The geneset analysis was performed using \href{https://github.com/sansomlab/gsfisher}{gsfisher}
+\item Please see \href{https://github.com/sansomlab/tenx}{https://github/sansomlab/tenx} for more details.
+\end{itemize}
+
+The key parameter choices used for this analysis were:
 
 \begin{itemize}
 \item The number of \reductionType{} components: \nPCs
+\item The number of nearest neighbors: \nnK
+\item The distance metric used for the nearest neighbor graph: \nnMetric
 \item The resolution of the clustering: \resolution
 \item The clustering algorithm: \clusteringAlgorithm
 \item The differential expression test: \deTest
 \end{itemize}
 
-(The clustering algorithms avaliable are: 1 = original Louvain; 2 = Louvain algorithm with multilevel refinement; 3 = SLM algorithm.)
+
 
 \input{\tenxDir/pipelines/pipeline_seurat/taskSummary.tex}

--- a/pipelines/pipeline_seurat/introductionSection.tex
+++ b/pipelines/pipeline_seurat/introductionSection.tex
@@ -1,7 +1,7 @@
 The core of the data analysis was performed using \href{http://satijalab.org/seurat/}{Seurat} and \href{https://scanpy.readthedocs.io/}{scanpy}:
 
 \begin{itemize}
-\item The construction of the nearest neighbor graph, clustering and UMAP computation were performed using scanpy.
+\item The construction of the nearest neighbor graph, clustering and UMAP computation were performed using scanpy (or scvelo for use of hnswlib).
 \item The differential expression analysis was performed using Seurat.
 \item The geneset analysis was performed using \href{https://github.com/sansomlab/gsfisher}{gsfisher}
 \item Please see \href{https://github.com/sansomlab/tenx}{https://github/sansomlab/tenx} for more details.
@@ -13,6 +13,7 @@ The key parameter choices used for this analysis were:
 \item The number of \reductionType{} components: \nPCs
 \item The number of nearest neighbors: \nnK
 \item The distance metric used for the nearest neighbor graph: \nnMetric
+\item The method used for construction of the nearest neighbor graph: \nnMethod
 \item The resolution of the clustering: \resolution
 \item The clustering algorithm: \clusteringAlgorithm
 \item The differential expression test: \deTest

--- a/pipelines/pipeline_seurat/numbersSection.tex
+++ b/pipelines/pipeline_seurat/numbersSection.tex
@@ -1,6 +1,6 @@
-\section{Numbers of cells, genes and umis}
+\section{Plots of summary statistics}
 
-Plots of cell numbers by factors of interest (e.g. by cluster)
+Plots of summary statistics (e.g. cell number) by factor of interest (e.g. cluster)
 
 \input{\groupNumbersDir/number.plots}
 

--- a/pipelines/pipeline_seurat/phateSection.tex
+++ b/pipelines/pipeline_seurat/phateSection.tex
@@ -3,12 +3,12 @@
 See: https://www.nature.com/articles/s41587-019-0336-3.
 
 \begin{figure}[H]
-\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\phateDir/phate.2D}}}
+\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\phateDir/phate.\resolution.2D}}}
 \caption{2D Phate map}
 \end{figure}
 
 \begin{figure}[H]
-\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\phateDir/phate.3D}}}
+\includegraphics[width=1.0\textwidth,height=0.9\textheight,keepaspectratio]{{{\phateDir/phate.\resolution.3D}}}
 \caption{3D Phate map}
 \end{figure}
 

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -195,7 +195,7 @@ qc:
 singleR:
 
   # number of cores for multiprocessing
-  workers: 10
+  workers: 4
 
   plot_extra: False
 
@@ -334,6 +334,70 @@ cluster:
   # By default Seurat will use the RANN package to build the nearest-neighbor
   # graph before clustering. This package uses the euclidean (L2) metric.
 
+
+# Data summary plots
+# ---------------------
+
+# Summary plots of data statistics
+# --------------------------------
+#
+# Each plot is individually defined.
+#
+# title: the name of the plot for the report (the key is used as the file basename)
+#
+# group: major grouping factor (must be present in metadata)
+# subgroup: either a factor or None (must be present in metadata if set)
+# subgrouplevels: manually order levels for plots (comma separated list)
+#
+# replicate: if set the pct stat will be normalised to total counts per-replicate.
+#            if not set the pct stat will be computed within the grouped data.
+#
+# stat: the statistic to plot. Either:
+#
+#       (1)  "count" or "pct" which will be computed from the grouped date (dplyr)
+#       (2) a column from the metadata
+#       (3) "ngenes" or "total_UMI" which will be computed on the seurat object
+#           (if not present in the metadata)
+#
+# trans: transformation to apply to the y axis (only "sqrt" supported)
+#
+# geom: the plot geom to use: supported are 'bar' and 'boxplot'
+#
+# facet: should the plot be facted by the major grouping factor?
+# freey: whould the y scales be free (when facetting)
+#
+# width: width of the plot in inches
+# height: height of the plot in inches
+# ncol: number of columns for facets
+#
+# for a full list of the options supported please see the
+# R/plot_group_numbers.R script
+#
+
+# Note: (i) in titles and labels % symbols must be escaped as %%
+#       (ii) use of underscores in titles is not supported.
+#
+
+summaries:
+
+  cells_by_cluster:
+    title: Cells by cluster
+    group: cluster
+    subgroup: None
+    replicate: None
+    stat: pct
+    geom: bar
+    facet: False
+    freey: False
+    xlab: cluster
+    ylab: cells (%%)
+    width: 8
+    height: 4
+
+
+
+
+
 # Plotting parameters
 # -------------------
 
@@ -363,6 +427,14 @@ plot:
   # Size of data points
   pointsize: 0.5
 
+  # maximum number of cells to draw (for gene expression plots)
+  maxcells: 200000
+
+  # violin point size
+  vpointsize: 0.1
+
+  # violin number of columns
+  vncol: 4
 
 # tSNE parameters
 # ---------------
@@ -489,6 +561,8 @@ findmarkers:
     # Only test genes that are detected in a minimum fraction of min.pct cells
     # (see min.pct=...)
     minpct: 0.1
+
+    maxcellsperident: 50000
     #
     # Within-cluster differential expression (optional)
     # ------------------------------------------------
@@ -539,6 +613,8 @@ findmarkers:
 # ------------------------------
 
 exprsreport:
+
+    workers: 12
 
    # Count of up-regulated markers to represent in tSNE plots for each cluster
     n_positive: 50

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -69,6 +69,37 @@ run:
   genesets: False
   cellbrowser: False
 
+
+# Give the pipeline a head start?
+# --------------------------------
+#
+# whenever possible to save time and disk space
+# we should link in previous  outputs rather than
+# re-computing them unnecessarily
+
+headstart:
+
+  # the path to a previous pipeline run
+  # False | /path/to/run
+  path: False
+
+  # Link in the annotation?
+  # True | False
+  annotation: False
+
+  # Link in the seurat_object?
+  # True | False
+  seurat_object: False
+
+  # Link in the singleR output?
+  # True | False
+  singleR: False
+
+  # Link in the data exported for python?
+  # True | False
+  export_for_python: False
+
+
 # Gene annotations
 # ----------------
 
@@ -147,6 +178,25 @@ runspecs:
 
     # Runs to skip (comma separated list of subfolders within each sample directory)
     skip:
+
+
+# Nearest neighbor parameters
+# --------------------------
+neighbors:
+  # The number of neighbors to use when constructing the nearest neighbor graph
+  # - it is recommended to match the value chosen for UMAP
+  n_neighbors: 20
+
+  # the distance metric (as supported by Scanpy)
+  # e.g. euclidean | cosine
+  metric: euclidean
+
+# Clustering parameters
+# ---------------------
+cluster:
+  # Clustering algorithm (as supported by Scanpy)
+  # "leiden" | "louvain"
+  algorithm: leiden
 
 
 # QC parameters
@@ -312,23 +362,6 @@ jackstraw:
   ## Determine statistical significance of PCA scores (see seurat_jackstraw.R)
   # Number of replicate samplings to perform (see Seurat::JackStraw)
   n_replicate: 100
-
-
-
-# Clustering parameters
-# ---------------------
-cluster:
-  # Clustering algorithm(s)
-  # (see Seurat::FindClusters)
-  # 1 = louvain, 4 = leiden
-  algorithm: 4
-
-  # The number of neighbors to use when constructing the nearest neighbor graph
-  # - it is recommended to match the value chosen for UMAP
-  nneighbors: 20
-
-  # By default Seurat will use the RANN package to build the nearest-neighbor
-  # graph before clustering. This package uses the euclidean (L2) metric.
 
 
 # Data summary plots
@@ -686,19 +719,19 @@ gmt_pathway_files:
   #
   # > human msigdb sets >
   #
-  # msigdb_biocarta: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.biocarta.v6.1.entrez.gmt
-  # msigdb_reactome: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.reactome.v6.1.entrez.gmt
-  # msigdb_canonical_pathways: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.v6.1.entrez.gmt
-  # msigdb_tf_motifs: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c3.tft.v6.1.entrez.gmt
-  # msigdb_immunological_signatures: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c7.all.v6.1.entrez.gmt
+  # msigdb_biocarta: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.biocarta.v7.1.entrez.gmt
+  # msigdb_reactome: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.reactome.v7.1.entrez.gmt
+  # msigdb_canonical_pathways: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.v7.1.entrez.gmt
+  # msigdb_tf_motifs: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c3.tft.v7.1.entrez.gmt
+  # msigdb_immunological_signatures: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c7.all.v7.1.entrez.gmt
   #
   # > mouse msigdb sets >
   #
-  # msigdb_biocarta: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.biocarta.v6.1.entrez.mouse.gmt
-  # msigdb_reactome: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.reactome.v6.1.entrez.mouse.gmt
-  # msigdb_canonical_pathways: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c2.cp.v6.1.entrez.mouse.gmt
-  # msigdb_tf_motifs: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c3.tft.v6.1.entrez.mouse.gmt
-  # msigdb_immunological_signatures: /gfs/mirror/msigdb/msigdb_v6.1/msigdb_v6.1_GMTs/c7.all.v6.1.entrez.mouse.gmt
+  # msigdb_biocarta: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.biocarta.v7.1.entrez.mouse.gmt
+  # msigdb_reactome: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.reactome.v7.1.entrez.mouse.gmt
+  # msigdb_canonical_pathways: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c2.cp.v7.1.entrez.mouse.gmt
+  # msigdb_tf_motifs: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c3.tft.v7.1.entrez.mouse.gmt
+  # msigdb_immunological_signatures: /gfs/mirror/msigdb/msigdb_v7.1/msigdb_v7.1_GMTs/c7.all.v7.1.entrez.mouse.gmt
 
 gmt_celltype_files:
   # > human cell types >

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -187,13 +187,13 @@ runspecs:
 neighbors:
 
   # scanpy | hnsw
-  methods: scanpy
+  methods: hnsw
 
   # for hnsw
   threads: 4
 
   # for hnsw
-  full_speed: True
+  full_speed: False
 
   # The number of neighbors to use when constructing the nearest neighbor graph
   # - it is recommended to match the value chosen for UMAP

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -185,6 +185,16 @@ runspecs:
 # Nearest neighbor parameters
 # --------------------------
 neighbors:
+
+  # scanpy | hnsw
+  methods: scanpy
+
+  # for hnsw
+  threads: 4
+
+  # for hnsw
+  full_speed: True
+
   # The number of neighbors to use when constructing the nearest neighbor graph
   # - it is recommended to match the value chosen for UMAP
   n_neighbors: 20

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -34,6 +34,8 @@ resources:
   # (ScaleData and JackStraw)
   numcores: 12
 
+  memory_min: 8G
+
   # Memory options for the different steps
   # Memory_low is used for tasks: velocity,
   # characteriseClusterMarkers*, plotMarkerNumbers*,

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -138,15 +138,6 @@ runspecs:
     # (see Seurat::FindClusters)
     cluster_resolutions: 0.6,1
 
-    # Clustering algorithm(s)
-    # (see Seurat::FindClusters)
-    # 1 = louvain, 4 = leiden
-    cluster_algorithms: 4
-
-
-    # Differential expression testing method(s)
-    # Choices: 'wilcox'|'bimod'|'roc'|'t'|'tobit'|'poisson'|'negbinom'|'MAST'|'DESeq2'
-    de_tests: wilcox
 
     # To manually specify cluster assignments set to True
     # - Manual cluster assignmets should be provided as sample_name.cluster_ids.rds file(s)
@@ -327,6 +318,11 @@ jackstraw:
 # Clustering parameters
 # ---------------------
 cluster:
+  # Clustering algorithm(s)
+  # (see Seurat::FindClusters)
+  # 1 = louvain, 4 = leiden
+  algorithm: 4
+
   # The number of neighbors to use when constructing the nearest neighbor graph
   # - it is recommended to match the value chosen for UMAP
   nneighbors: 20
@@ -427,6 +423,9 @@ plot:
   # Size of data points
   pointsize: 0.5
 
+  # set the point shape:
+  pointpch: 16
+
   # maximum number of cells to draw (for gene expression plots)
   maxcells: 200000
 
@@ -435,6 +434,8 @@ plot:
 
   # violin number of columns
   vncol: 4
+  vnrow: 3
+
 
 # tSNE parameters
 # ---------------
@@ -554,6 +555,11 @@ knownmarkers:
 # ----------------------
 
 findmarkers:
+    numcores: 1
+    # Differential expression testing method(s)
+    # Choices: 'wilcox'|'bimod'|'roc'|'t'|'tobit'|'poisson'|'negbinom'|'MAST'|'DESeq2'
+    test: wilcox
+
     ## Differential expression parameters (see Seurat::FindMarkers)
     # Limit testing to genes which show, on average, at least X-fold difference
     # (see logfc.threshold=...)

--- a/pipelines/pipeline_seurat/rdimsVisSection.tex
+++ b/pipelines/pipeline_seurat/rdimsVisSection.tex
@@ -1,5 +1,7 @@
 \section{Visualisation of clusters and factors of interest}
 
-\input{\rdimsVisDir/plot.rdims.factor}
+\input{\rdimsVisClusterDir/plot.rdims.factor}
+
+\input{\rdimsVisFactorDir/plot.rdims.factor}
 
 \clearpage

--- a/pipelines/pipeline_utils/TASK.py
+++ b/pipelines/pipeline_utils/TASK.py
@@ -1,0 +1,74 @@
+import os
+import math
+import types
+
+def get_resources(memory="4G", cpu=1):
+    '''calculate the resource requirements and return a
+       dictonary that can be used to update the local variables'''
+
+    if not memory.endswith("G"):
+        raise ValueError("Memory must be specified as XXG")
+
+    gb_requested = int(memory[:-1])
+
+    mem_gb = int(math.ceil(gb_requested / float(cpu) ))
+
+    spec = {"job_memory": str(mem_gb) + "G",
+            "job_threads": cpu,
+            "r_memory": gb_requested * 1000}
+
+    return(spec["job_threads"],
+           spec["job_memory"],
+           spec["r_memory"])
+
+
+def get_vars(infile, outfile, PARAMS):
+    '''
+    Make a dictionary of commonly need paths and parameteres
+    '''
+
+    outfile = os.path.relpath(outfile)
+
+    parts = outfile.split("/")
+
+    nparts = len(parts)
+
+    SPEC = { "sample_name": parts[0].split(".")[0],
+             "sample_dir": parts[0],
+             "seurat_object": os.path.join(parts[0], "begin.rds"),
+             "outdir": os.path.dirname(outfile),
+             "outname": os.path.basename(outfile),
+             "resolutions" : [x.strip()
+                              for x in
+                              PARAMS["runspecs_cluster_resolutions"].split(",")]
+             }
+
+    if not infile is None:
+        infile = os.path.relpath(infile)
+        SPEC["indir"] = os.path.dirname(infile)
+        SPEC["inname"] = os.path.basename(infile)
+
+    # take care of making the output directory.
+    if not os.path.exists(SPEC["outdir"]):
+        os.makedirs(SPEC["outdir"])
+
+    if outfile.endswith(".sentinel"):
+        SPEC["log_file"] = outfile.replace(".sentinel", ".log")
+
+    # if we are in the component directory
+    if nparts >= 3 and parts[1].startswith("components."):
+
+        SPEC["component_dir"] = os.path.join(parts[0], parts[1])
+        SPEC["components"] = parts[1].split(".")[1]
+        graph_path = os.path.join(parts[0], parts[1], "graphs.rds")
+
+        SPEC["seurat_graphs"] =  graph_path
+
+    # if we are in the cluster directory
+    if nparts >= 4 and parts[2].startswith("cluster."):
+
+        SPEC["cluster_dir"] = os.path.join(parts[0], parts[1], parts[2])
+        SPEC["resolution"] = parts[2][len("cluster."):-len(".dir")]
+        SPEC["cluster_ids"] = os.path.join(SPEC["cluster_dir"], "cluster_ids.rds")
+
+    return([types.SimpleNamespace(**SPEC), SPEC])

--- a/pipelines/pipeline_utils/TASK.py
+++ b/pipelines/pipeline_utils/TASK.py
@@ -1,6 +1,7 @@
 import os
 import math
 import types
+import pandas as pd
 
 def get_resources(memory="4G", cpu=1):
     '''calculate the resource requirements and return a
@@ -22,7 +23,7 @@ def get_resources(memory="4G", cpu=1):
            spec["r_memory"])
 
 
-def get_vars(infile, outfile, PARAMS):
+def get_vars(infile, outfile, PARAMS, make_outdir=True):
     '''
     Make a dictionary of commonly need paths and parameteres
     '''
@@ -48,9 +49,11 @@ def get_vars(infile, outfile, PARAMS):
         SPEC["indir"] = os.path.dirname(infile)
         SPEC["inname"] = os.path.basename(infile)
 
-    # take care of making the output directory.
-    if not os.path.exists(SPEC["outdir"]):
-        os.makedirs(SPEC["outdir"])
+    if(make_outdir):
+
+        # take care of making the output directory.
+        if not os.path.exists(SPEC["outdir"]):
+            os.makedirs(SPEC["outdir"])
 
     if outfile.endswith(".sentinel"):
         SPEC["log_file"] = outfile.replace(".sentinel", ".log")
@@ -64,11 +67,29 @@ def get_vars(infile, outfile, PARAMS):
 
         SPEC["seurat_graphs"] =  graph_path
 
+        anndata_path = os.path.join(SPEC["component_dir"],
+                                    "anndata.dir",
+                                    "anndata.h5ad")
+
+        if os.path.exists(anndata_path):
+            SPEC["anndata"] = anndata_path
+
     # if we are in the cluster directory
     if nparts >= 4 and parts[2].startswith("cluster."):
 
         SPEC["cluster_dir"] = os.path.join(parts[0], parts[1], parts[2])
         SPEC["resolution"] = parts[2][len("cluster."):-len(".dir")]
         SPEC["cluster_ids"] = os.path.join(SPEC["cluster_dir"], "cluster_ids.rds")
+        SPEC["cluster_assignments"] = os.path.join(SPEC["cluster_dir"], "cluster_assignments.tsv.gz")
+        SPEC["cluster_colors"] = os.path.join(SPEC["cluster_dir"], "cluster_colors.tsv")
+
+        # get the list of clusters
+        cluster_table = os.path.join(SPEC["cluster_dir"], "cluster_ids.tsv")
+        if os.path.exists(cluster_table):
+            clusters = pd.read_table(cluster_table, header=None)
+            clusters = clusters[clusters.columns[0]].tolist()
+            SPEC["cluster_table"] = cluster_table
+            SPEC["clusters"] = [x for x in set(clusters)]
+            SPEC["nclusters"] = len(SPEC["clusters"])
 
     return([types.SimpleNamespace(**SPEC), SPEC])

--- a/pipelines/pipeline_utils/spec.py
+++ b/pipelines/pipeline_utils/spec.py
@@ -1,0 +1,43 @@
+import os
+
+def get(infile, outfile, PARAMS):
+    '''
+    Make a dictionary of commonly need paths and parameteres
+    '''
+
+    parts = outfile.split("/")
+    print("***********")
+    print(parts)
+    nparts = len(parts)
+
+    spec = { "sample_name": parts[0].split(".")[0],
+             "seurat_object": os.path.join(parts[0], "begin.rds"),
+             "outdir": os.path.dirname(outfile),
+             "indir": os.path.dirname(infile),
+             "resolutions" : [x.strip()
+                              for x in
+                              PARAMS["runspecs_cluster_resolutions"].split(",")]
+             }
+
+    # take care of making the output directory.
+    if not os.path.exists(spec["outdir"]):
+        os.mkdir(spec["outdir"])
+
+    if outfile.endswith(".sentinel"):
+        spec["log_file"] = outfile.replace(".sentinel", ".log")
+
+    # if we are in the component directory
+    if nparts >= 3:
+
+        spec["components"] = parts[1].split(".")[1]
+        graph_path = os.path.join(parts[0], parts[1], "graph.rds")
+
+        if os.path.exists(graph_path):
+            spec["graph"] =  graph_path
+
+    # if we are in the cluster directory
+    if nparts >= 4:
+
+        spec["resolution"] = parts[2][len("cluster."):-len(".dir")]
+
+    return(spec)

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -9,6 +9,7 @@ from matplotlib import rcParams
 from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as pl
 import seaborn as sns
+import pegasus as pg
 import scanpy as sc
 import pandas as pd
 from scipy import sparse
@@ -36,33 +37,30 @@ sc.logging.print_versions()
 # ######################## Parse the arguments ############################## #
 # ########################################################################### #
 
-
+L.info("parsing arguments")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz", type=str,
                     help="File with reduced dimensions")
 parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
                     help="File with the cell barcodes")
-# parser.add_argument("--features_file", default="features.tsv.gz", type=str,
-#                     help="File with the feature names")
 parser.add_argument("--outdir",default=1, type=str,
                     help="path to output directory")
-parser.add_argument("--cluster_assignments", default=1, type=str,
-                    help="gzipped tsv file with cell cluster assignments")
-parser.add_argument("--cluster_colors", default=1, type=str,
-                    help="tsv file with the color palette for the clusters")
 parser.add_argument("--comps", default="1", type=str,
-                    help="Number of dimensions to include in knn and umap computation")
+                    help="Number of dimensions to include in the knn computation")
 parser.add_argument("--k", default=20, type=int,
                     help="number of neighbors")
+parser.add_argument("--metric", default="euclidean", type=str,
+                    help="the distance metric")
+parser.add_argument("--threads", default=16, type=int,
+                    help="number of threads")
+parser.add_argument("--full-speed", default=False, action="store_true",
+                    help="number of threads")
 
 args = parser.parse_args()
 
-
-
-
-
-
+L.info("Running with arguments:")
+print(args)
 
 # ########################################################################### #
 # ############## Create outdir and set results file ######################### #
@@ -74,12 +72,6 @@ results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # figures folder
 sc.settings.figdir = args.outdir
-
-# Get the color palette
-ggplot_palette = [x for x in pd.read_csv(args.cluster_colors,
-                      header=None, sep="\t")[0].values]
-
-ggplot_cmap = ListedColormap(sns.color_palette(ggplot_palette).as_hex())
 
 sc.settings.set_figure_params(dpi=300, dpi_save=300)
 
@@ -105,74 +97,24 @@ reduced_dims_mat = reduced_dims_mat[select_comps]
 
 L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
 
-adata.obsm['X_pca'] = reduced_dims_mat.to_numpy(dtype="float32")
-
-# Read and add cluster ids
-df = pd.read_csv(args.cluster_assignments,sep="\t")
-df.index = df["barcode"]
-
-# Ensure correct ordering
-adata.obs['cluster_id'] = df.loc[adata.obs.index,"cluster_id"].astype("category").values
+adata.obsm['X_rdims'] = reduced_dims_mat.to_numpy(dtype="float32")
 
 # Run neighbors
 L.info( "Using " + str(args.k) + " neighbors")
 
-sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_pca')
+# L.info("Computing nn using hnswlib as implemented in the pegasus package")
+
+# pg.neighbors(adata,K=args.k, rep="rdim", n_jobs= args.threads,
+#             full_speed=args.full-speed)
+
+sc.pp.neighbors(adata,
+                n_neighbors = args.k,
+                metric = args.metric,
+                use_rep = 'X_rdims')
 
 
-print(ggplot_palette)
-
-# Run, plot and save umap
-sc.tl.umap(adata)
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".png", show=False, palette=ggplot_palette)
-
-adata.obsm["X_umap_init_pre"] = adata.obsm["X_umap"]
-
-# Run and plot paga
-sc.tl.paga(adata, groups='cluster_id')
-sc.pl.paga(adata, save=".png", show=False, cmap=ggplot_cmap)
-
-# Run, plot and store paga-initialised umap
-sc.tl.umap(adata, init_pos = sc.tl._utils.get_init_pos_from_paga(adata))
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".paga.initialised.png", show=False,
-           palette=ggplot_palette)
-
-adata.obsm['X_umap_init_pos'] = adata.obsm['X_umap']
-
-# Rename X_umap_init_pos
-del adata.obsm['X_umap']
-adata.obsm['X_umap'] = adata.obsm['X_umap_init_pre']
-del adata.obsm['X_umap_init_pre']
-
-# Save paga-initialised UMAP coordinates
-umap_pos=pd.DataFrame(adata.obs['barcode'])
-umap_pos['x coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,0]).values
-umap_pos['y coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,1]).values
-
-out = args.outdir + '/UMAP_init_pos.csv'
-umap_pos.to_csv(out,index=False)
-
-# Write output file
-adata.write(results_file)
-
-# Compute and plot the force directed graph (FDG)
-sc.tl.draw_graph(adata)
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".png", show=False, palette=ggplot_palette)
-
-# Compute and plot the PAGA initialised FDG
-sc.tl.draw_graph(adata, init_pos='paga')
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".paga.initialised.png", show=False, palette=ggplot_palette)
-
-
-paga_fa2 = pd.DataFrame(adata.obsm["X_draw_graph_fa"],
-                                    index=adata.obs['barcode'],
-                                    columns=["FA1","FA2"])
-
-paga_fa2.to_csv(os.path.join(args.outdir, "paga_init_fa2.tsv.gz"),
-                             sep="\t")
+# compute clusters
+adata.write(os.path.join(args.outdir,
+                         "anndata.h5ad"))
 
 L.info("Complete")

--- a/python/run_cluster.py
+++ b/python/run_cluster.py
@@ -9,6 +9,7 @@ from matplotlib import rcParams
 from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as pl
 import seaborn as sns
+import anndata
 import scanpy as sc
 import pandas as pd
 from scipy import sparse
@@ -21,8 +22,12 @@ import sys
 # ###################### Set up the logging ################################# #
 # ########################################################################### #
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-L = logging.getLogger("run_paga")
+L = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(sys.stdout)
+log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+log_handler.setLevel(logging.INFO)
+L.addHandler(log_handler)
+L.setLevel(logging.INFO)
 
 
 sc.settings.verbosity = 3  # verbosity: errors (0), warnings (1), info (2), hints (3)
@@ -36,21 +41,19 @@ sc.logging.print_versions()
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz", type=str,
-                    help="File with reduced dimensions")
-parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
+parser.add_argument("--anndata", default="anndata.h5ad", type=str,
                     help="File with the cell barcodes")
-parser.add_argument("--outdir",default=1, type=str,
+parser.add_argument("--algorithm",default="leiden", type=str,
+                    help="the clustering algorithm to use")
+parser.add_argument("--outdir",default=".", type=str,
                     help="path to output directory")
 parser.add_argument("--resolution", default=1, type=str,
                     help="the clustering resolution")
-parser.add_argument("--comps", default="1", type=str,
-                    help="Number of dimensions to include in knn and umap computation")
-parser.add_argument("--k", default=20, type=int,
-                    help="number of neighbors")
 
 args = parser.parse_args()
 
+L.info("Running with arguments:")
+print(args)
 
 
 # ########################################################################### #
@@ -59,7 +62,6 @@ args = parser.parse_args()
 
 
 # write folder
-results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # figures folder
 sc.settings.figdir = args.outdir
@@ -70,35 +72,19 @@ sc.settings.set_figure_params(dpi=300, dpi_save=300)
 # ############################### Run PAGA ################################## #
 # ########################################################################### #
 
-
-# Read matrix of reduced dimensions, create anndata and add dimensions
-reduced_dims_mat = pd.read_csv(args.reduced_dims_matrix_file, sep="\t")
-reduced_dims_mat.index = [x for x in pd.read_csv(args.barcode_file, header=None)[0]]
-
-adata = sc.AnnData(obs=[x for x in reduced_dims_mat.index])
-adata.obs.index = reduced_dims_mat.index
-adata.obs.rename(columns={0:'barcode'}, inplace=True)
-
-# Add dimensions to anndata
-colnames = list(reduced_dims_mat.columns)
-colname_prefix = list(set([re.sub(r'_[0-9]+', '', i) for i in colnames]))[0] + "_"
-select_comps = args.comps.split(",")
-select_comps = [ colname_prefix + item for item in select_comps]
-reduced_dims_mat = reduced_dims_mat[select_comps]
-
-L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
-
-adata.obsm['X_rdim'] = reduced_dims_mat.to_numpy(dtype="float32")
-
-# Run neighbors
-L.info( "Using " + str(args.k) + " neighbors")
-
-sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_rdims')
+adata = anndata.read_h5ad(args.anndata)
 
 # compute clusters
-sc.tl.leiden(adata, resolution=float(args.resolution))
+resolution = float(args.resolution)
 
-adata.to_csv(os.path.join(args.outdir,
-                          "clusters.tsv.gz"), sep="\t", index=False)
+if args.algorithm == "leiden":
+    sc.tl.leiden(adata, resolution=resolution)
+elif args.algorithm == "louvain":
+    sc.tl.louvain(adata, resolution=resolution)
+else:
+    raise ValueError("Clustering algorithm not recognised")
+
+adata.obs.to_csv(os.path.join(args.outdir,
+                          "scanpy.clusters.tsv.gz"), sep="\t", index=False)
 
 L.info("Complete")

--- a/python/run_cluster.py
+++ b/python/run_cluster.py
@@ -40,24 +40,16 @@ parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz",
                     help="File with reduced dimensions")
 parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
                     help="File with the cell barcodes")
-# parser.add_argument("--features_file", default="features.tsv.gz", type=str,
-#                     help="File with the feature names")
 parser.add_argument("--outdir",default=1, type=str,
                     help="path to output directory")
-parser.add_argument("--cluster_assignments", default=1, type=str,
-                    help="gzipped tsv file with cell cluster assignments")
-parser.add_argument("--cluster_colors", default=1, type=str,
-                    help="tsv file with the color palette for the clusters")
+parser.add_argument("--resolution", default=1, type=str,
+                    help="the clustering resolution")
 parser.add_argument("--comps", default="1", type=str,
                     help="Number of dimensions to include in knn and umap computation")
 parser.add_argument("--k", default=20, type=int,
                     help="number of neighbors")
 
 args = parser.parse_args()
-
-
-
-
 
 
 
@@ -71,12 +63,6 @@ results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # figures folder
 sc.settings.figdir = args.outdir
-
-# Get the color palette
-ggplot_palette = [x for x in pd.read_csv(args.cluster_colors,
-                      header=None, sep="\t")[0].values]
-
-ggplot_cmap = ListedColormap(sns.color_palette(ggplot_palette).as_hex())
 
 sc.settings.set_figure_params(dpi=300, dpi_save=300)
 
@@ -104,72 +90,15 @@ L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
 
 adata.obsm['X_pca'] = reduced_dims_mat.to_numpy(dtype="float32")
 
-# Read and add cluster ids
-df = pd.read_csv(args.cluster_assignments,sep="\t")
-df.index = df["barcode"]
-
-# Ensure correct ordering
-adata.obs['cluster_id'] = df.loc[adata.obs.index,"cluster_id"].astype("category").values
-
 # Run neighbors
 L.info( "Using " + str(args.k) + " neighbors")
 
 sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_pca')
 
+# compute clusters
+sc.tl.leiden(adata, resolution=float(args.resolution))
 
-print(ggplot_palette)
-
-# Run, plot and save umap
-sc.tl.umap(adata)
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".png", show=False, palette=ggplot_palette)
-
-adata.obsm["X_umap_init_pre"] = adata.obsm["X_umap"]
-
-# Run and plot paga
-sc.tl.paga(adata, groups='cluster_id')
-sc.pl.paga(adata, save=".png", show=False, cmap=ggplot_cmap)
-
-# Run, plot and store paga-initialised umap
-sc.tl.umap(adata, init_pos = sc.tl._utils.get_init_pos_from_paga(adata))
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".paga.initialised.png", show=False,
-           palette=ggplot_palette)
-
-adata.obsm['X_umap_init_pos'] = adata.obsm['X_umap']
-
-# Rename X_umap_init_pos
-del adata.obsm['X_umap']
-adata.obsm['X_umap'] = adata.obsm['X_umap_init_pre']
-del adata.obsm['X_umap_init_pre']
-
-# Save paga-initialised UMAP coordinates
-umap_pos=pd.DataFrame(adata.obs['barcode'])
-umap_pos['x coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,0]).values
-umap_pos['y coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,1]).values
-
-out = args.outdir + '/UMAP_init_pos.csv'
-umap_pos.to_csv(out,index=False)
-
-# Write output file
-adata.write(results_file)
-
-# Compute and plot the force directed graph (FDG)
-sc.tl.draw_graph(adata)
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".png", show=False, palette=ggplot_palette)
-
-# Compute and plot the PAGA initialised FDG
-sc.tl.draw_graph(adata, init_pos='paga')
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".paga.initialised.png", show=False, palette=ggplot_palette)
-
-
-paga_fa2 = pd.DataFrame(adata.obsm["X_draw_graph_fa"],
-                                    index=adata.obs['barcode'],
-                                    columns=["FA1","FA2"])
-
-paga_fa2.to_csv(os.path.join(args.outdir, "paga_init_fa2.txt.gz"),
-                             sep="\t")
+adata.to_csv(os.path.join(args.outdir,
+                          "clusters.tsv.gz"), sep="\t", index=False)
 
 L.info("Complete")

--- a/python/run_cluster.py
+++ b/python/run_cluster.py
@@ -88,12 +88,12 @@ reduced_dims_mat = reduced_dims_mat[select_comps]
 
 L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
 
-adata.obsm['X_pca'] = reduced_dims_mat.to_numpy(dtype="float32")
+adata.obsm['X_rdim'] = reduced_dims_mat.to_numpy(dtype="float32")
 
 # Run neighbors
 L.info( "Using " + str(args.k) + " neighbors")
 
-sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_pca')
+sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_rdims')
 
 # compute clusters
 sc.tl.leiden(adata, resolution=float(args.resolution))

--- a/python/run_phate.py
+++ b/python/run_phate.py
@@ -22,8 +22,12 @@ import phate
 # ###################### Set up the logging ################################# #
 # ########################################################################### #
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-L = logging.getLogger("run_paga")
+L = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(sys.stdout)
+log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+log_handler.setLevel(logging.INFO)
+L.addHandler(log_handler)
+L.setLevel(logging.INFO)
 
 
 # ########################################################################### #

--- a/python/run_scvelo.py
+++ b/python/run_scvelo.py
@@ -20,8 +20,12 @@ import argparse
 # ###################### Set up the logging ################################# #
 # ########################################################################### #
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-L = logging.getLogger("run_scvelo")
+L = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(sys.stdout)
+log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+log_handler.setLevel(logging.INFO)
+L.addHandler(log_handler)
+L.setLevel(logging.INFO)
 
 sc.settings.verbosity = 3  # verbosity: errors (0), warnings (1), info (2), hints (3)
 sc.logging.print_versions()

--- a/python/run_umap.py
+++ b/python/run_umap.py
@@ -9,6 +9,7 @@ from matplotlib import rcParams
 from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as pl
 import seaborn as sns
+import anndata
 import scanpy as sc
 import pandas as pd
 from scipy import sparse
@@ -21,9 +22,13 @@ import sys
 # ###################### Set up the logging ################################# #
 # ########################################################################### #
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-L = logging.getLogger("run_paga")
-
+#logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+L = logging.getLogger(__name__)
+log_handler = logging.StreamHandler(sys.stdout)
+log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+log_handler.setLevel(logging.INFO)
+L.addHandler(log_handler)
+L.setLevel(logging.INFO)
 
 sc.settings.verbosity = 3  # verbosity: errors (0), warnings (1), info (2), hints (3)
 sc.logging.print_versions()
@@ -33,29 +38,18 @@ sc.logging.print_versions()
 # ######################## Parse the arguments ############################## #
 # ########################################################################### #
 
-
-
 parser = argparse.ArgumentParser()
-parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz", type=str,
-                    help="File with reduced dimensions")
-parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
+parser.add_argument("--anndata", default="anndata.h5ad", type=str,
                     help="File with the cell barcodes")
 parser.add_argument("--outdir",default=1, type=str,
                     help="path to output directory")
-parser.add_argument("--cluster_assignments", default=1, type=str,
-                    help="gzipped tsv file with cell cluster assignments")
-parser.add_argument("--comps", default="1", type=str,
-                    help="Number of dimensions to include in knn and umap computation")
-parser.add_argument("--k", default=20, type=int,
-                    help="number of neighbors")
+# parser.add_argument("--resolution", default=1, type=str,
+#                     help="the clustering resolution")
 
 args = parser.parse_args()
 
-
-
-
-
-
+L.info("Running with arguments:")
+print(args)
 
 # ########################################################################### #
 # ############## Create outdir and set results file ######################### #
@@ -63,7 +57,6 @@ args = parser.parse_args()
 
 
 # write folder
-results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # figures folder
 sc.settings.figdir = args.outdir
@@ -74,47 +67,18 @@ sc.settings.set_figure_params(dpi=300, dpi_save=300)
 # ############################### Run PAGA ################################## #
 # ########################################################################### #
 
+adata = anndata.read_h5ad(args.anndata)
 
-# Read matrix of reduced dimensions, create anndata and add dimensions
-reduced_dims_mat = pd.read_csv(args.reduced_dims_matrix_file, sep="\t")
-reduced_dims_mat.index = [x for x in pd.read_csv(args.barcode_file, header=None)[0]]
-
-adata = sc.AnnData(obs=[x for x in reduced_dims_mat.index])
-adata.obs.index = reduced_dims_mat.index
-adata.obs.rename(columns={0:'barcode'}, inplace=True)
-
-# Add dimensions to anndata
-colnames = list(reduced_dims_mat.columns)
-colname_prefix = list(set([re.sub(r'_[0-9]+', '', i) for i in colnames]))[0] + "_"
-select_comps = args.comps.split(",")
-select_comps = [ colname_prefix + item for item in select_comps]
-reduced_dims_mat = reduced_dims_mat[select_comps]
-
-L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
-
-adata.obsm['X_pca'] = reduced_dims_mat.to_numpy(dtype="float32")
-
-# Read and add cluster ids
-df = pd.read_csv(args.cluster_assignments,sep="\t")
-df.index = df["barcode"]
-
-# Ensure correct ordering
-adata.obs['cluster_id'] = df.loc[adata.obs.index,"cluster_id"].astype("category").values
-
-# Run neighbors
-L.info( "Using " + str(args.k) + " neighbors")
-
-sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_pca')
-
-
-
-# Run, plot and save umap
+# compute clusters
 sc.tl.umap(adata)
 
-result  = pd.DataFrame(adata.obsm["X_umap"], columns=["UMAP_1", "UMAP_2"])
-result["barcode"] = adata.obs["barcode"]
+umap  = pd.DataFrame(adata.obsm["X_umap"], columns=["UMAP_1", "UMAP_2"])
+umap["barcode"] = adata.obs["barcode"].values
 
-result.to_csv(os.path.join(args.outdir,
-                           "umap.txt.gz"))
+
+umap.to_csv(os.path.join(args.outdir,
+                      "umap.tsv.gz"), sep="\t",
+         index=False)
+
 
 L.info("Complete")

--- a/python/run_umap.py
+++ b/python/run_umap.py
@@ -40,14 +40,10 @@ parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz",
                     help="File with reduced dimensions")
 parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
                     help="File with the cell barcodes")
-# parser.add_argument("--features_file", default="features.tsv.gz", type=str,
-#                     help="File with the feature names")
 parser.add_argument("--outdir",default=1, type=str,
                     help="path to output directory")
 parser.add_argument("--cluster_assignments", default=1, type=str,
                     help="gzipped tsv file with cell cluster assignments")
-parser.add_argument("--cluster_colors", default=1, type=str,
-                    help="tsv file with the color palette for the clusters")
 parser.add_argument("--comps", default="1", type=str,
                     help="Number of dimensions to include in knn and umap computation")
 parser.add_argument("--k", default=20, type=int,
@@ -71,12 +67,6 @@ results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # figures folder
 sc.settings.figdir = args.outdir
-
-# Get the color palette
-ggplot_palette = [x for x in pd.read_csv(args.cluster_colors,
-                      header=None, sep="\t")[0].values]
-
-ggplot_cmap = ListedColormap(sns.color_palette(ggplot_palette).as_hex())
 
 sc.settings.set_figure_params(dpi=300, dpi_save=300)
 
@@ -117,59 +107,14 @@ L.info( "Using " + str(args.k) + " neighbors")
 sc.pp.neighbors(adata, n_neighbors = args.k, use_rep = 'X_pca')
 
 
-print(ggplot_palette)
 
 # Run, plot and save umap
 sc.tl.umap(adata)
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".png", show=False, palette=ggplot_palette)
 
-adata.obsm["X_umap_init_pre"] = adata.obsm["X_umap"]
+result  = pd.DataFrame(adata.obsm["X_umap"], columns=["UMAP_1", "UMAP_2"])
+result["barcode"] = adata.obs["barcode"]
 
-# Run and plot paga
-sc.tl.paga(adata, groups='cluster_id')
-sc.pl.paga(adata, save=".png", show=False, cmap=ggplot_cmap)
-
-# Run, plot and store paga-initialised umap
-sc.tl.umap(adata, init_pos = sc.tl._utils.get_init_pos_from_paga(adata))
-sc.pl.umap(adata, color="cluster_id", legend_loc='on data',
-           save = ".paga.initialised.png", show=False,
-           palette=ggplot_palette)
-
-adata.obsm['X_umap_init_pos'] = adata.obsm['X_umap']
-
-# Rename X_umap_init_pos
-del adata.obsm['X_umap']
-adata.obsm['X_umap'] = adata.obsm['X_umap_init_pre']
-del adata.obsm['X_umap_init_pre']
-
-# Save paga-initialised UMAP coordinates
-umap_pos=pd.DataFrame(adata.obs['barcode'])
-umap_pos['x coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,0]).values
-umap_pos['y coordinate'] = pd.DataFrame(adata.obsm['X_umap_init_pos'][:,1]).values
-
-out = args.outdir + '/UMAP_init_pos.csv'
-umap_pos.to_csv(out,index=False)
-
-# Write output file
-adata.write(results_file)
-
-# Compute and plot the force directed graph (FDG)
-sc.tl.draw_graph(adata)
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".png", show=False, palette=ggplot_palette)
-
-# Compute and plot the PAGA initialised FDG
-sc.tl.draw_graph(adata, init_pos='paga')
-sc.pl.draw_graph(adata, color='cluster_id', legend_loc='on data',
-                 save=".paga.initialised.png", show=False, palette=ggplot_palette)
-
-
-paga_fa2 = pd.DataFrame(adata.obsm["X_draw_graph_fa"],
-                                    index=adata.obs['barcode'],
-                                    columns=["FA1","FA2"])
-
-paga_fa2.to_csv(os.path.join(args.outdir, "paga_init_fa2.txt.gz"),
-                             sep="\t")
+result.to_csv(os.path.join(args.outdir,
+                           "umap.txt.gz"))
 
 L.info("Complete")

--- a/tenxutils/R/Plot.R
+++ b/tenxutils/R/Plot.R
@@ -131,11 +131,12 @@ plotFvE <- function(data, p_col="p.adj", label_col="gene",
 plotViolins <- function(data, seurat_object,
                         cluster_ids, type="positive",
                         group.by=NULL, ident.include=NULL,
-                        ncol=ncol,
+                        vncol=4, vnrow=3,
                         use.minfc=FALSE,
                         minfc_col="min_logFC", maxfc_col="max_logFC",
                         avgfc_col="avg_logFC",
                         m_col="avg_logFC", p_col="p.adj",
+                        pt_size=0.1,
                         id_col="gene")
 {
 
@@ -155,24 +156,35 @@ plotViolins <- function(data, seurat_object,
         stop("type argument to plotViolins() not recognised")
     }
 
+    n_show = vncol * vnrow
+
     ## make first sub-figure (4 columns, 3 rows)
     tmp <- tmp[order(tmp[[p_col]]),]
 
-    genes_a <- tmp[[id_col]][min(1,length(tmp[[id_col]])):min(12,length(tmp[[id_col]]))]
+    genes_a <- tmp[[id_col]][min(1,length(tmp[[id_col]])):min(n_show,length(tmp[[id_col]]))]
     n_a <- length(genes_a)
 
     message("number of genes for first panel: ", n_a)
 
-    nrow_a <- ceiling(n_a / 4)
+    nrow_a <- ceiling(n_a / vncol)
+
+    FontSize(
+        x.text = 4,
+        y.text = 6,
+        x.title = 0,
+    #    y.title = NULL,
+        main = 10
+    #    ...
+        )
 
     if(n_a > 0)
     {
         message("Calling VlnPlot for top genes by p-value")
         gpa <- VlnPlot(object=seurat_object,
                        features=genes_a,
-                       pt.size = 0.1,
+                       pt.size = pt_size,
                        #size.x.use=6,size.y.use=6,size.title.use=10, point.size.use=0.1,
-                       ncol=ncol,
+                       ncol=vncol,
                        log=TRUE,
                        # do.return=TRUE,
                        group.by=group.by,
@@ -186,8 +198,8 @@ plotViolins <- function(data, seurat_object,
         nrow_a <- 0
     }
 
-    ## if n_a is less than 12, there are no more genes to show.
-    if(n_a == 12)
+    ## if n_a is less than n_show, there are no more genes to show.
+    if(n_a == n_show)
     {
 
         ## make second sub-figure
@@ -219,9 +231,9 @@ plotViolins <- function(data, seurat_object,
             }
         }
 
-        genes_b <- tmp[[id_col]][min(1,length(tmp[[id_col]])):min(12,length(tmp[[id_col]]))]
+        genes_b <- tmp[[id_col]][min(1,length(tmp[[id_col]])):min(n_show,length(tmp[[id_col]]))]
         n_b <- length(genes_b)
-        nrow_b <- ceiling(n_b/4)
+        nrow_b <- ceiling(n_b/vncol)
 
         message("number of genes for second panel: ", n_b)
 
@@ -231,9 +243,9 @@ plotViolins <- function(data, seurat_object,
             message("Calling VlnPlot for top genes by fold change")
             gpb <- VlnPlot(object=seurat_object,
                            features=genes_b,
-                           pt.size = 0.1,
+                           pt.size = pt_size,
                            #size.x.use=6,size.y.use=6,size.title.use=10, point.size.use=0.1,
-                           ncol=ncol,
+                           ncol=vncol,
                            log=TRUE, #do.return=TRUE,
                            group.by=group.by,
                            idents=ident.include)
@@ -272,7 +284,8 @@ plotViolins <- function(data, seurat_object,
 #' @param fc_type The metric by which the violin plots are ordered
 violinPlotSection <- function(data, seurat_object, cluster_ids, type="positive",
                               group.by=opt$testfactor,
-                              ident.include=opt$identinclude, ncol=ncol,
+                              ident.include=opt$identinclude,
+                              vncol=4,vnrow=3, pt_size=0.1,
                               outdir=opt$outdir,
                               analysis_title="violin plots", fc_type="fold change",
                               plot_dir_var="plotsDir",
@@ -282,8 +295,8 @@ violinPlotSection <- function(data, seurat_object, cluster_ids, type="positive",
 
     ## get the violin plots
     violin_plots <- plotViolins(data, seurat_object, cluster_ids, type=type,
-                                group.by=group.by,
-                                ident.include=ident.include, ncol=ncol,
+                                group.by=group.by, pt_size=pt_size,
+                                ident.include=ident.include, vncol=vncol, vnrow=vnrow,
                                 use.minfc=use.minfc)
 
 
@@ -434,6 +447,7 @@ save_ggplots <- function(filepath=NULL,
                width=width,
                height=height,
                units="in",
+               type="cairo-png",
                dpi=dpi)
     }
 


### PR DESCRIPTION
As per the commit messages:

- various improvements in plotting (particularly plot_group_numbers.R)
- pipeline is reflowed for efficiency so that results common across parameter combinations are only computed once.
- A single choice of algorithm for clustering and de testing must now be made.
- scanpy is now used for the knn (*), UMAP and clustering steps
- *hnsw can be specified for nearest neighbor identification (we use hnswlib via scvelo). It provides superior results that are very close to the default exact computation performed in Seurat (RANN).
- s/txt/tsv/ throughout
- various tweaks throughout to improve memory usage and run time.
- task parameters are provided automatically by pipeline_utils/TASK.py whenever possible.

The pipeline can now handle very large datasets. Because it now uses a hybrid approach pipeline_seurat.py will soon be renamed to something more generic.

A few tasks still need to be updated (including for scvelo, diffusion maps).