### PR TITLE
KJ optionally use h5seurat instead of rds

### DIFF
--- a/R/convert_rds_to_anndata.R
+++ b/R/convert_rds_to_anndata.R
@@ -1,0 +1,29 @@
+## Export data to be used as input for analysis with python
+## packages such as scanpy
+
+# Libraries ----
+
+stopifnot(
+  require(optparse),
+  require(Seurat),
+  require(SeuratDisk),
+  require(tenxutils)
+)
+
+# Options ----
+
+option_list <- list(
+  make_option(c("--seuratobject"), default="begin.Robj",
+              help="A seurat object after dimensionality reduction")
+)
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+cat("Running with options:\n")
+print(opt)
+
+output_file = gsub(".h5seurat", ".h5ad", opt$seuratobject)
+
+Convert(opt$seuratobject, dest = output_file, overwrite = TRUE, verbose = TRUE) 
+
+print("Completed")

--- a/R/export_for_python.R
+++ b/R/export_for_python.R
@@ -6,7 +6,6 @@
 stopifnot(
   require(optparse),
   require(Seurat),
-  require(SeuratDisk),
   require(tenxutils)
 )
 
@@ -61,6 +60,7 @@ if (endsWith(opt$seuratobject, ".rds")) {
    s <- readRDS(opt$seuratobject)
 } else {
    message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+   stopifnot(require(SeuratDisk))
    s <- LoadH5Seurat(opt$seuratobject)
 }
 

--- a/R/export_for_python.R
+++ b/R/export_for_python.R
@@ -6,6 +6,7 @@
 stopifnot(
   require(optparse),
   require(Seurat),
+  require(SeuratDisk),
   require(tenxutils)
 )
 
@@ -55,8 +56,14 @@ exportMetaData <- function(seurat_object, outdir=NULL) {
 
 
 # Read RDS seurat object
-message("readRDS")
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+   message(sprintf("readRDS: %s", opt$seuratobject))
+   s <- readRDS(opt$seuratobject)
+} else {
+   message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+   s <- LoadH5Seurat(opt$seuratobject)
+}
+
 message("export_for_python running with default assay: ", DefaultAssay(s))
 
 # Write out the cell and feature names

--- a/R/plot_group_numbers.R
+++ b/R/plot_group_numbers.R
@@ -179,8 +179,15 @@ if(opt$stat %in% c("total_UMI", "ngenes"))
     {
         require(Seurat)
         # add the statistic from the seurat object
-        s <- readRDS(opt$seuratobject)
-
+        if (endsWith(opt$seuratobject, ".rds")) {
+          message(sprintf("readRDS: %s", opt$seuratobject))
+          s <- readRDS(opt$seuratobject)
+        } else {
+          require(SeuratDisk)
+          message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+          s <- LoadH5Seurat(opt$seuratobject)
+        }
+      
         ## set the default assay
         message("Setting default assay to: ", opt$seuratassay)
         DefaultAssay(s) <- opt$seuratassay

--- a/R/plot_rdims_gene.R
+++ b/R/plot_rdims_gene.R
@@ -23,6 +23,7 @@ stopifnot(
   require(ggplot2),
   require(reshape2),
   require(Seurat),
+  require(SeuratDisk),
   require(tenxutils),
   require(BiocParallel),
   require(Matrix)
@@ -120,8 +121,14 @@ cat("Running with options:\n")
 print(opt)
 
 
-## read in the raw count matrix
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 
 ## set the default assay
 message("Setting default assay to: ", opt$seuratassay)

--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -8,6 +8,7 @@ stopifnot(
   require(ggplot2),
   require(reshape2),
   require(Seurat),
+  require(SeuratDisk),
   require(tenxutils)
 )
 
@@ -59,7 +60,13 @@ genes <- read.table(opt$genetable,
 
 
 ## read in the raw count matrix
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 Idents(s) <- readRDS(opt$clusterids)
 
 ## set the default assay

--- a/R/scanpy_post_process_clusters.R
+++ b/R/scanpy_post_process_clusters.R
@@ -5,6 +5,7 @@
 stopifnot(
   require(optparse),
   require(Seurat),
+  require(SeuratDisk),
   require(dplyr),
   require(Matrix),
   require(reshape2),
@@ -32,8 +33,13 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-message(sprintf("readRDS: %s", opt$seuratobject))
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 
 message("seurat_cluster.R running with default assay: ", DefaultAssay(s))

--- a/R/seurat_FindMarkers.R
+++ b/R/seurat_FindMarkers.R
@@ -78,7 +78,14 @@ plan("multiprocess",
      workers = opt$numcores)
 
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 cluster_ids <- readRDS(opt$clusterids)
 
 have_gene_ids <- "gene_id" %in% colnames(s@misc)

--- a/R/seurat_begin.R
+++ b/R/seurat_begin.R
@@ -42,7 +42,6 @@ option_list <- list(
         c("--matrixtype"), default="10X",
         help="either 10X or rds"
     ),
-
     make_option(
         c("--project"),
         default="SeuratAnalysis",
@@ -53,6 +52,11 @@ option_list <- list(
         default="seurat.out.dir",
         help="Location for outputs files. Must exist."
         ),
+    make_option(
+      c("--file_type"),
+      default="rds",
+      help="Which type of file to use (rds or h5seurat)"
+    ),
     make_option(
         c("--metadata"),
         default="none",
@@ -674,6 +678,16 @@ print(
 message("seurat_begin.R object final default assay: ", DefaultAssay(s))
 
 # Save the R object
-saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+if (opt$file_type == "rds") {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  SaveH5Seurat(s, file=file.path(opt$outdir, "begin.h5seurat"), overwrite = TRUE)
+  
+}
+
+
 
 message("Completed")

--- a/R/seurat_characteriseClusterDEGenes.R
+++ b/R/seurat_characteriseClusterDEGenes.R
@@ -187,7 +187,14 @@ tex <- c(tex, getFigureTex(defn, deCaption,plot_dir_var=opt$plotdirvar))
 ## enforce significance
 
 ## read in the seurat object
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 

--- a/R/seurat_clusterStats.R
+++ b/R/seurat_clusterStats.R
@@ -8,6 +8,7 @@
 stopifnot(
   require(optparse),
   require(Seurat),
+  require(SeuratDisk),
   require(future),
   require(dplyr),
   require(Matrix),
@@ -52,7 +53,13 @@ cat("Running with options:\n")
 print(opt)
 
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 cluster_ids <- readRDS(opt$clusterids)
 
 if(!identical(colnames(x = s),names(cluster_ids)))

--- a/R/seurat_compare_clusters.R
+++ b/R/seurat_compare_clusters.R
@@ -34,8 +34,14 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-message(sprintf("readRDS: %s", opt$seuratobject))
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
 

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -48,9 +48,15 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
+if (endsWith(opt$seuratobject, ".rds")) {
+    message(sprintf("readRDS: %s", opt$seuratobject))
+    s <- readRDS(opt$seuratobject)
+} else {
+    message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+    stopifnot(require(SeuratDisk))
+    s <- LoadH5Seurat(opt$seuratobject)
+}
 
-message("readRDS")
-s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 

--- a/R/seurat_explore_hvg_and_cell_cycle.R
+++ b/R/seurat_explore_hvg_and_cell_cycle.R
@@ -200,7 +200,15 @@ options(future.globals.maxSize = opt$memory * 1024^2)
 
 # Input data ----
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 
 ## ######################################################################### ##
 ## # (i) Initial normalisation, variable gene identification and scaling ### ##

--- a/R/seurat_find_neighbors.R
+++ b/R/seurat_find_neighbors.R
@@ -87,7 +87,14 @@ options(future.globals.maxSize = opt$memory * 1024^2)
 
 # Input data ----
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 if(opt$usesigcomponents)
 {

--- a/R/seurat_get_assay_data.R
+++ b/R/seurat_get_assay_data.R
@@ -63,8 +63,14 @@ cat("Running with options:\n")
 print(opt)
 
 
-## read in the raw count matrix
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 ## set the default assay
 message("Setting default assay to: ", opt$seuratassay)

--- a/R/seurat_jackstraw.R
+++ b/R/seurat_jackstraw.R
@@ -30,7 +30,14 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 ## In Macosko et al, we implemented a resampling test inspired by the jackStraw procedure.
 ## We randomly permute a subset of the data (1% by default) and rerun PCA,

--- a/R/seurat_normalise_and_scale.R
+++ b/R/seurat_normalise_and_scale.R
@@ -221,7 +221,14 @@ options(future.globals.maxSize = opt$memory * 1024^2)
 
 # Input data ----
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 ## ######################################################################### ##
 ## # (i) Initial normalisation, variable gene identification and scaling ## ##
@@ -351,6 +358,11 @@ if(opt$normalizationmethod=="sctransform")
 message("seurat_begin.R object final default assay: ", DefaultAssay(s))
 
 # Save the R object
-saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+if (endsWith(opt$seuratobject, ".rds")) {
+  saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+} else {
+  stopifnot(require(SeuratDisk))
+  SaveH5Seurat(s, file=file.path(opt$outdir, "begin.h5seurat"), overwrite = TRUE)
+}
 
 message("Completed")

--- a/R/seurat_pca.R
+++ b/R/seurat_pca.R
@@ -115,7 +115,14 @@ options(future.globals.maxSize = opt$memory * 1024^2)
 
 # Input data ----
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 
 ## ######################################################################### ##
 ## ################### (vi) Dimension reduction (PCA) ###################### ##
@@ -200,6 +207,11 @@ if(opt$normalizationmethod!="sctransform" & opt$jackstraw)
 message("seurat_begin.R object final default assay: ", DefaultAssay(s))
 
 # Save the R object
-saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+if (endsWith(opt$seuratobject, ".rds")) {
+  saveRDS(s, file=file.path(opt$outdir, "begin.rds"))
+} else {
+  stopifnot(require(SeuratDisk))
+  SaveH5Seurat(s, file=file.path(opt$outdir, "begin.h5seurat"), overwrite = TRUE)
+}
 
 message("Completed")

--- a/R/seurat_summariseMarkers.R
+++ b/R/seurat_summariseMarkers.R
@@ -40,7 +40,14 @@ if(!is.null(opt$subgroup)) { opt$subgroup <- strsplit(opt$subgroup,",")[[1]]}
 cat("Running with options:\n")
 print(opt)
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 

--- a/R/seurat_summariseMarkersBetween.R
+++ b/R/seurat_summariseMarkersBetween.R
@@ -48,7 +48,14 @@ print(opt)
 # set the run specs
 run_specs <- paste(opt$numpcs,opt$resolution,opt$algorithm,opt$testuse,sep="_")
 
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
 cluster_ids <- readRDS(opt$clusterids)
 
 message("Setting the default seurat assay to: ", opt$seuratassay)

--- a/R/seurat_tsne.R
+++ b/R/seurat_tsne.R
@@ -46,7 +46,15 @@ print(opt)
 
 
 message("readRDS")
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 cluster_ids <- readRDS(opt$clusterids)
 Idents(s) <- cluster_ids
 print(head(Idents(s)))

--- a/R/seurat_umap.R
+++ b/R/seurat_umap.R
@@ -52,7 +52,15 @@ print(opt)
 
 
 message("readRDS")
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 s@graphs <- readRDS(opt$seuratgraphs)
 
 message("seurat_umap.R running with default assay: ", DefaultAssay(s))

--- a/R/singleR_extra_plots.R
+++ b/R/singleR_extra_plots.R
@@ -35,8 +35,15 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-message(sprintf("readRDS: %s", opt$seuratobject))
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 a <- ifelse("SCT" %in% names(s), yes = "SCT", no = "RNA")
 
 sce <- as.SingleCellExperiment(s, assay = a) # Seems to be using SCT assay (so does it take the defualt?)

--- a/R/singleR_plots.R
+++ b/R/singleR_plots.R
@@ -38,8 +38,15 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-message(sprintf("readRDS: %s", opt$seuratobject))
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+  message(sprintf("readRDS: %s", opt$seuratobject))
+  s <- readRDS(opt$seuratobject)
+} else {
+  message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+  stopifnot(require(SeuratDisk))
+  s <- LoadH5Seurat(opt$seuratobject)
+}
+
 a <- ifelse("SCT" %in% names(s), yes = "SCT", no = "RNA")
 
 sce <- as.SingleCellExperiment(s, assay = a) # Seems to be using SCT assay (so does it take the defualt?)

--- a/R/singleR_run.R
+++ b/R/singleR_run.R
@@ -35,8 +35,14 @@ opt <- parse_args(OptionParser(option_list=option_list))
 cat("Running with options:\n")
 print(opt)
 
-message(sprintf("readRDS: %s", opt$seuratobject))
-s <- readRDS(opt$seuratobject)
+if (endsWith(opt$seuratobject, ".rds")) {
+   message(sprintf("readRDS: %s", opt$seuratobject))
+   s <- readRDS(opt$seuratobject)
+} else {
+   message(sprintf("LoadH5Seurat: %s", opt$seuratobject))
+   stopifnot(require(SeuratDisk))
+   s <- LoadH5Seurat(opt$seuratobject)
+}
 a <- ifelse("SCT" %in% names(s), yes = "SCT", no = "RNA")
 
 sce <- as.SingleCellExperiment(s, assay = a) # Seems to be using SCT assay (so does it take the defualt?)

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -808,6 +808,10 @@ def convertRDStoAnndata(infile, outfile):
 
     spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
 
+    # set the job threads and memory
+    job_threads, job_memory, r_memory = TASK.get_resources(
+        memory=PARAMS["resources_memory_standard"])
+
     statement = '''Rscript %(tenx_dir)s/R/convert_rds_to_anndata.R
                        --seuratobject=%(seurat_object)s
                        &> %(log_file)s

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -296,6 +296,7 @@ def createSeuratObject(infile, outfile):
                    --matrixtype=%(matrix_type)s
                    --project=%(sample_name)s
                    --outdir=%(outdir)s
+                   --file_type=%(input_format)s
                    --groupby=%(qc_groupby)s
                    --mingenes=%(qc_initial_mingenes)s
                    --mincells=%(qc_mincells)s
@@ -512,12 +513,14 @@ def seuratPCA(infile, outfile):
 # ############### Predict cell-types using singleR ################### #
 # #################################################################### #
 
+file_suffix = str(PARAMS["input_format"])
+print(file_suffix)
 
 @active_if(PARAMS["headstart_seurat_object"])
 @transform(os.path.join(str(PARAMS["headstart_path"]),
-                        "*.seurat.dir/begin.rds"),
-           regex(r".*/(.*).seurat.dir/begin.rds"),
-                 r"\1.seurat.dir/begin.rds")
+                        "*.seurat.dir/begin."+file_suffix),
+           regex(r".*/(.*).seurat.dir/begin."+file_suffix),
+                 rf"\1.seurat.dir/begin."+file_suffix)
 def headstart(infile, outfile):
     '''
     link in the begin.rds objects

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -697,14 +697,19 @@ def plotExtraSingleR(infile, outfile):
 # ############ Begin per-parameter combination analysis runs ################ #
 # ########################################################################### #
 
+USE_RDS = 0
+USE_H5 = 0
+
 if PARAMS["input_format"] == "rds":
     SEURAT_OBJECTS = "*.seurat.dir/begin.rds"
     S_REGEX = regex(r"(.*)/begin.rds")
+    USE_RDS = 1
 else:
     SEURAT_OBJECTS = "*.seurat.dir/begin.h5seurat"
     S_REGEX = regex(r"(.*)/begin.h5seurat")
+    USE_H5 = 1
 
-
+@active_if(USE_RDS)
 @follows(seuratPCA, headstart)
 @transform(SEURAT_OBJECTS,
            S_REGEX,
@@ -790,6 +795,30 @@ def exportForPython(infile, outfile):
         P.run(statement)
         IOTools.touch_file(outfile)
 
+@active_if(USE_H5)
+@follows(seuratPCA, headstart)
+@transform(SEURAT_OBJECTS,
+           S_REGEX,
+           r"\1/export_for_python.sentinel")
+def convertRDStoAnndata(infile, outfile):
+    '''Convert Seurat h5ad to anndata h5ad '''
+
+    spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
+
+    statement = '''Rscript %(tenx_dir)s/R/convert_rds_to_anndata.R
+                       --seuratobject=%(seurat_object)s
+                       &> %(log_file)s
+                    ''' % dict(PARAMS, **SPEC, **locals())
+
+    P.run(statement)
+    IOTools.touch_file(outfile)
+
+
+if PARAMS["input_format"] == "rds":
+    TASK_EXPORT = exportForPython
+else:
+    TASK_EXPORT = convertRDStoAnndata
+
 
 def genAnndata():
 
@@ -814,8 +843,7 @@ def genAnndata():
             outfile = os.path.join(sample, outdir, subdir, outname)
             yield [infile, outfile]
 
-
-@follows(exportForPython)
+@follows(TASK_EXPORT)
 @files(genAnndata)
 def anndata(infile, outfile):
     '''
@@ -826,8 +854,14 @@ def anndata(infile, outfile):
 
     reductiontype = PARAMS["dimreduction_method"]
 
-    reduced_dims_matrix_file = os.path.join(spec.sample_dir,
-                                            "embedding." + reductiontype + ".tsv.gz")
+    if PARAMS["input_format"] == "rds":
+        reduced_dims_matrix_file = os.path.join(spec.sample_dir,
+                                                "embedding." + reductiontype + ".tsv.gz")
+        input_files = '''--reduced_dims_matrix_file=%(reduced_dims_matrix_file)s '''
+    else:
+        anndata_file = SPEC["seurat_object"].replace(".h5seurat", ".h5ad")
+        input_files = '''--anndata_file=%(anndata_file)s
+                         --reduction_name=%(dimreduction_method)s '''
 
     barcode_file = os.path.join(spec.sample_dir,
                                 "barcodes.tsv.gz")
@@ -855,7 +889,7 @@ def anndata(infile, outfile):
         memory=PARAMS["resources_memory_extreme"])
 
     statement = '''python %(tenx_dir)s/python/make_anndata.py
-                   --reduced_dims_matrix_file=%(reduced_dims_matrix_file)s
+                   %(input_files)s
                    --barcode_file=%(barcode_file)s
                    --outdir=%(outdir)s
                    --comps=%(comps)s
@@ -1087,7 +1121,7 @@ def paga(infile, outfile):
 
 
 @active_if(PARAMS["run_phate"])
-@follows(exportForPython,cluster)
+@follows(TASK_EXPORT, cluster)
 @transform(anndata,
            regex(r"(.*)/(.*)/anndata.dir/anndata.sentinel"),
            r"\1/\2/phate.dir/phate.sentinel")
@@ -1117,22 +1151,29 @@ def phate(infile, outfile):
 
     cluster_resolutions = ",".join(spec.resolutions)
 
-    barcode_file = os.path.join(spec.sample_dir,
-                                "barcodes.tsv.gz")
 
-    if PARAMS["phate_assay"] == "reduced.dimensions":
-
-        embeddings = ".".join(["embedding",
-                               PARAMS["dimreduction_method"],
-                               "tsv.gz"])
-
-        assay_data = os.path.join(spec.sample_dir, embeddings)
-
-    elif PARAMS["phate_assay"] == "scaled.data":
-        assay_data = os.path.join(spec.sample_dir, "assay.scale.data.tsv.gz")
-
+    if USE_H5:
+        # path to anndata object
+        assay_data = os.path.join(spec.sample_dir, "begin.h5ad")
+        if PARAMS["phate_assay"] == "reduced.dimensions":
+            # add red dimension name to extract from anndata
+            input_phate = '''--reduction_name=%(dimreduction_method)s
+                             --input_type="anndata" '''
     else:
-        raise ValueError("PHATE assay not recognised")
+        barcode_file = os.path.join(spec.sample_dir,
+                                    "barcodes.tsv.gz")
+        input_phate = ''' --barcode_file=%(barcode_file)s
+                          --input_type="tsv" '''
+        if PARAMS["phate_assay"] == "reduced.dimensions":
+            embeddings = ".".join(["embedding",
+                                   PARAMS["dimreduction_method"],
+                                   "tsv.gz"])
+            assay_data = os.path.join(spec.sample_dir, embeddings)
+
+        elif PARAMS["phate_assay"] == "scaled.data":
+            assay_data = os.path.join(spec.sample_dir, "assay.scale.data.tsv.gz")
+        else:
+            raise ValueError("PHATE assay not recognised")
 
 
     k = PARAMS["phate_k"]
@@ -1144,13 +1185,13 @@ def phate(infile, outfile):
     statement = '''python %(tenx_dir)s/python/run_phate.py
                    --data=%(assay_data)s
                    --assay=%(phate_assay)s
-                   --barcode_file=%(barcode_file)s
                    --outdir=%(outdir)s
                    --resolution=%(cluster_resolutions)s
                    --cluster_assignments=%(cluster_assignment_files)s
                    --cluster_colors=%(cluster_color_files)s
                    --k=%(k)s
                    --gif=%(phate_gif)s
+                   %(input_phate)s
                    &> %(log_file)s
                 ''' % dict(PARAMS, **SPEC, **locals())
 
@@ -1408,6 +1449,10 @@ def scvelo(infile, outfile):
         runs["phate"] = {"method": "phate",
                          "table": phate_table,
                          "rdim1": "PHATE1", "rdim2": "PHATE2"}
+    if USE_H5:
+        input_type = ''' --input_type="anndata" '''
+    else:
+        input_type = ''' --input_type="tsv" '''
 
     statements = []
 
@@ -1433,6 +1478,7 @@ def scvelo(infile, outfile):
                    --rdims=%(r_tab)s
                    --rdim1=%(r_1)s
                    --rdim2=%(r_2)s
+                   %(input_type)s
                 &> %(this_log_file)s
                 ''' % dict(PARAMS, **SPEC, **locals())
 
@@ -1448,7 +1494,7 @@ def scvelo(infile, outfile):
 
 @transform(RDIMS_VIS_TASK,
            regex(r"(.*)/(.*)/(.*)/(.*).sentinel"),
-           add_inputs(exportForPython),
+           add_inputs(TASK_EXPORT),
            r"\1/\2/rdims.visualisation.dir/plot.rdims.factor.sentinel")
 def plotRdimsFactors(infiles, outfile):
     '''
@@ -1801,7 +1847,7 @@ def plotRdimsGenes(infile, outfile):
 # ################# plot per-cluster summary statistics ##################### #
 # ########################################################################### #
 
-@follows(exportForPython)
+@follows(TASK_EXPORT)
 @transform(cluster,
            regex(r"(.*)/cluster.sentinel"),
            r"\1/group.numbers.dir/plot.group.numbers.sentinel")

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -544,7 +544,10 @@ def headstart(infile, outfile):
 def genSingleRjobs():
     '''generate the singleR jobs'''
 
-    seurat_objects = glob.glob("*.seurat.dir/begin.rds")
+    if PARAMS["input_format"] == "rds":
+        seurat_objects = glob.glob("*.seurat.dir/begin.rds")
+    else:
+        seurat_objects = glob.glob("*.seurat.dir/begin.h5seurat")
 
     references = [x.strip() for x in PARAMS["singleR_reference"].split(",")]
 
@@ -610,7 +613,6 @@ def singleR(infile, outfile):
 
         spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
 
-
         # set the job threads and memory
         job_threads, job_memory, r_memory = TASK.get_resources(
             memory=PARAMS["resources_memory_extreme"],
@@ -637,6 +639,8 @@ def plotSingleR(infile, outfile):
     '''Make the singleR heatmap'''
 
     spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
+    print(spec)
+    print(SPEC)
 
     predictions = os.path.join(spec.indir,
                                "predictions.rds")
@@ -693,10 +697,17 @@ def plotExtraSingleR(infile, outfile):
 # ############ Begin per-parameter combination analysis runs ################ #
 # ########################################################################### #
 
+if PARAMS["input_format"] == "rds":
+    SEURAT_OBJECTS = "*.seurat.dir/begin.rds"
+    S_REGEX = regex(r"(.*)/begin.rds")
+else:
+    SEURAT_OBJECTS = "*.seurat.dir/begin.h5seurat"
+    S_REGEX = regex(r"(.*)/begin.h5seurat")
+
 
 @follows(seuratPCA, headstart)
-@transform("*.seurat.dir/begin.rds",
-           regex(r"(.*)/begin.rds"),
+@transform(SEURAT_OBJECTS,
+           S_REGEX,
            r"\1/export_for_python.sentinel")
 def exportForPython(infile, outfile):
     '''
@@ -790,7 +801,10 @@ def genAnndata():
 
     for sample in samples:
 
-        infile = os.path.join(sample, "begin.rds")
+        if PARAMS["input_format"] == "rds":
+            infile = os.path.join(sample, "begin.rds")
+        else:
+            infile = os.path.join(sample, "begin.h5seurat")
 
         for comps in components:
 
@@ -870,7 +884,10 @@ def genScanpyClusterJobs():
 
     for sample in samples:
 
-        infile = os.path.join(sample, "begin.rds")
+        if PARAMS["input_format"] == "rds":
+            infile = os.path.join(sample, "begin.rds")
+        else:
+            infile = os.path.join(sample, "begin.h5seurat")
 
         for comps in components:
 

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -1351,7 +1351,7 @@ RDIMS_VIS_COMP_2 = "UMAP_2"
 # ########################################################################### #
 
 @active_if(PARAMS["run_velocity"])
-@follows(paga)
+@follows(paga, phate)
 @transform(RDIMS_VIS_TASK,
            regex(r"(.*)/(.*)/(.*).sentinel"),
            r"\1/velocity.dir/scvelo.sentinel")

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -1239,9 +1239,9 @@ def UMAP(infile, outfile):
 # ########################################################################### #
 
 @active_if(PARAMS["run_diffusionmap"])
-@transform(anndata,
-           regex(r"(.*)/(.*)/anndata.dir/anndata.sentinel"),
-           r"\1/\2/diffusionmap.dir/dm.sentinel")
+@transform(cluster,
+           regex(r"(.*)/(.*)/(.*)/cluster.sentinel"),
+           r"\1/\2/\3/diffusionmap.dir/dm.sentinel")
 def diffusionMap(infile, outfile):
     '''
     Run the diffusion map analysis on a saved seurat object.
@@ -1250,8 +1250,6 @@ def diffusionMap(infile, outfile):
     ## TODO: fix plotting flow
 
     spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
-
-    cluster_ids = infile.replace(".sentinel","_ids.rds")
 
     if(spec.components=="sig"):
         comp="--usesigcomponents=TRUE"

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -26,6 +26,15 @@ matrix:
   #
   type: 10X
 
+input:
+  # currently supported are
+  # -----------------------
+  #
+  # "rds", for which the pipeline expects a
+  # file called 'begin.rds'
+  # "h5seurat", for which the pipeline expects
+  # a file called 'begin.h5seurat'
+  format: rds
 
 # compute resource options
 # ------------------------

--- a/pipelines/pipeline_utils/TASK.py
+++ b/pipelines/pipeline_utils/TASK.py
@@ -36,13 +36,17 @@ def get_vars(infile, outfile, PARAMS, make_outdir=True):
 
     SPEC = { "sample_name": parts[0].split(".")[0],
              "sample_dir": parts[0],
-             "seurat_object": os.path.join(parts[0], "begin.rds"),
              "outdir": os.path.dirname(outfile),
              "outname": os.path.basename(outfile),
              "resolutions" : [x.strip()
                               for x in
                               PARAMS["runspecs_cluster_resolutions"].split(",")]
              }
+
+    if PARAMS["input_format"] == "rds":
+        SPEC["seurat_object"] = os.path.join(parts[0], "begin.rds")
+    else:
+        SPEC["seurat_object"] = os.path.join(parts[0], "begin.h5seurat")
 
     if not infile is None:
         infile = os.path.relpath(infile)

--- a/pipelines/pipeline_utils/spec.py
+++ b/pipelines/pipeline_utils/spec.py
@@ -11,13 +11,16 @@ def get(infile, outfile, PARAMS):
     nparts = len(parts)
 
     spec = { "sample_name": parts[0].split(".")[0],
-             "seurat_object": os.path.join(parts[0], "begin.rds"),
              "outdir": os.path.dirname(outfile),
              "indir": os.path.dirname(infile),
              "resolutions" : [x.strip()
                               for x in
                               PARAMS["runspecs_cluster_resolutions"].split(",")]
              }
+    if PARAMS["input_format"] == "rds":
+        spec["seurat_object"] = os.path.join(parts[0], "begin.rds")
+    else:
+        spec["seurat_object"] = os.path.join(parts[0], "begin.h5seurat")
 
     # take care of making the output directory.
     if not os.path.exists(spec["outdir"]):

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -26,9 +26,9 @@ L.setLevel(logging.INFO)
 L.info("parsing arguments")
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz", type=str,
+parser.add_argument("--reduced_dims_matrix_file", default="none", type=str,
                     help="File with reduced dimensions")
-parser.add_argument("--anndata_file", default="anndata.h5ad", type=str,
+parser.add_argument("--anndata_file", default="none", type=str,
                     help="h5ad file with anndata")
 parser.add_argument("--reduction_name", default="pca", type=str,
                     help="Name of the dimension reduction")
@@ -69,7 +69,7 @@ results_file = args.outdir + "/" + "paga_anndata.h5ad"
 # select correct PCs
 select_comps = args.comps.split(",")
 
-if "anndata_file" in args:
+if not args.anndata_file == "none":
     L.info("Using converted h5ad from SeuratDisk")
     adata_input = anndata.read(args.anndata_file)
     adata_input.obs['barcode'] = pd.Series(adata_input.obs.index.copy(),
@@ -85,7 +85,7 @@ if "anndata_file" in args:
     L.info("Using comps " + ', '.join(rd_colnames))
 
 
-elif "reduced_dims_matrix_file" in args:
+elif not args.reduced_dims_matrix_file == "none":
     # Read matrix of reduced dimensions, create anndata and add dimensions
     reduced_dims_mat = pd.read_csv(args.reduced_dims_matrix_file, sep="\t")
     reduced_dims_mat.index = [x for x in pd.read_csv(args.barcode_file, header=None)[0]]

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -19,7 +19,6 @@ log_handler.setLevel(logging.INFO)
 L.addHandler(log_handler)
 L.setLevel(logging.INFO)
 
-
 # ########################################################################### #
 # ######################## Parse the arguments ############################## #
 # ########################################################################### #
@@ -29,6 +28,10 @@ L.info("parsing arguments")
 parser = argparse.ArgumentParser()
 parser.add_argument("--reduced_dims_matrix_file", default="reduced_dims.tsv.gz", type=str,
                     help="File with reduced dimensions")
+parser.add_argument("--anndata_file", default="anndata.h5ad", type=str,
+                    help="h5ad file with anndata")
+parser.add_argument("--reduction_name", default="pca", type=str,
+                    help="Name of the dimension reduction")
 parser.add_argument("--barcode_file", default="barcodes.tsv.gz", type=str,
                     help="File with the cell barcodes")
 parser.add_argument("--outdir",default=1, type=str,
@@ -60,30 +63,51 @@ print(args)
 results_file = args.outdir + "/" + "paga_anndata.h5ad"
 
 # ########################################################################### #
-# ############################### Run PAGA ################################## #
+# ######################## Make anndata object ############################## #
 # ########################################################################### #
 
-
-# Read matrix of reduced dimensions, create anndata and add dimensions
-reduced_dims_mat = pd.read_csv(args.reduced_dims_matrix_file, sep="\t")
-reduced_dims_mat.index = [x for x in pd.read_csv(args.barcode_file, header=None)[0]]
-
-adata = anndata.AnnData(obs=[x for x in reduced_dims_mat.index])
-adata.obs.index = reduced_dims_mat.index
-adata.obs.rename(columns={0:'barcode'}, inplace=True)
-
-# Add dimensions to anndata
-colnames = list(reduced_dims_mat.columns)
-colname_prefix = list(set([re.sub(r'_[0-9]+', '', i) for i in colnames]))[0] + "_"
+# select correct PCs
 select_comps = args.comps.split(",")
-select_comps = [ colname_prefix + item for item in select_comps]
-reduced_dims_mat = reduced_dims_mat[select_comps]
 
-n_pcs = len(select_comps)
+if "anndata_file" in args:
+    L.info("Using converted h5ad from SeuratDisk")
+    adata = anndata.read(args.anndata_file)
+    adata.obs['barcode'] = pd.Series(adata.obs.index.copy(),
+                                     index=adata.obs.index.copy())
 
-L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
+    # get name for obsm
+    obsm_use = 'X_' + str(args.reduction_name)
+    indeces = [int(i)-1 for i in select_comps]
+    L.info(indeces)
+    adata.obsm[obsm_use] = adata.obsm[obsm_use][:,indeces]
 
-adata.obsm['X_rdims'] = reduced_dims_mat.to_numpy(dtype="float32")
+    rd_colnames = [str(args.reduction_name)+"_"+str(i) for i in select_comps]
+    L.info("Using comps " + ', '.join(rd_colnames))
+
+
+elif "reduced_dims_matrix_file" in args:
+    # Read matrix of reduced dimensions, create anndata and add dimensions
+    reduced_dims_mat = pd.read_csv(args.reduced_dims_matrix_file, sep="\t")
+    reduced_dims_mat.index = [x for x in pd.read_csv(args.barcode_file, header=None)[0]]
+
+    adata = anndata.AnnData(obs=[x for x in reduced_dims_mat.index])
+    adata.obs.index = reduced_dims_mat.index
+    adata.obs.rename(columns={0:'barcode'}, inplace=True)
+
+    # Add dimensions to anndata
+    colnames = list(reduced_dims_mat.columns)
+    colname_prefix = list(set([re.sub(r'_[0-9]+', '', i) for i in colnames]))[0] + "_"
+    select_comps = args.comps.split(",")
+    select_comps = [ colname_prefix + item for item in select_comps]
+    reduced_dims_mat = reduced_dims_mat[select_comps]
+
+    L.info("Using comps " + ', '.join(list(reduced_dims_mat.columns)))
+
+    adata.obsm['X_rdims'] = reduced_dims_mat.to_numpy(dtype="float32")
+    obsm_use = 'X_rdims'
+
+else:
+    L.info("No input file present.")
 
 # Run neighbors
 L.info( "Using " + str(args.k) + " neighbors")
@@ -98,7 +122,7 @@ if args.method == "scanpy":
     neighbors(adata,
               n_neighbors = args.k,
               metric = args.metric,
-              use_rep = 'X_rdims')
+              use_rep = obsm_use)
 
 
 elif args.method == "hnsw":
@@ -113,7 +137,7 @@ elif args.method == "hnsw":
     neighbors(adata,
               n_neighbors = args.k,
               n_pcs = None,
-              use_rep = "X_rdims",
+              use_rep = obsm_use,
               knn = True,
               random_state = 0,
               method = 'hnsw',
@@ -130,5 +154,12 @@ else:
 # compute clusters
 adata.write(os.path.join(args.outdir,
                          "anndata.h5ad"))
+
+if "anndata_file" in args:
+    # write out metadata for other tasks
+    metadata_out = adata.obs.copy()
+    out_folder = os.path.dirname(args.anndata_file)
+    metadata_out.to_csv(os.path.join(out_folder, "metadata.tsv.gz"),
+                        sep="\t", index=False)
 
 L.info("Complete")

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -71,15 +71,15 @@ select_comps = args.comps.split(",")
 
 if "anndata_file" in args:
     L.info("Using converted h5ad from SeuratDisk")
-    adata = anndata.read(args.anndata_file)
-    adata.obs['barcode'] = pd.Series(adata.obs.index.copy(),
-                                     index=adata.obs.index.copy())
+    adata_input = anndata.read(args.anndata_file)
+    adata_input.obs['barcode'] = pd.Series(adata_input.obs.index.copy(),
+                                     index=adata_input.obs.index.copy())
 
     # get name for obsm
     obsm_use = 'X_' + str(args.reduction_name)
     indeces = [int(i)-1 for i in select_comps]
-    L.info(indeces)
-    adata.obsm[obsm_use] = adata.obsm[obsm_use][:,indeces]
+    adata = anndata.AnnData(obs=adata_input.obs.copy())
+    adata.obsm[obsm_use] = adata_input.obsm[obsm_use].copy()[:,indeces]
 
     rd_colnames = [str(args.reduction_name)+"_"+str(i) for i in select_comps]
     L.info("Using comps " + ', '.join(rd_colnames))
@@ -111,6 +111,7 @@ else:
 
 # Run neighbors
 L.info( "Using " + str(args.k) + " neighbors")
+L.info( "Computing neighbors based on obsm: " + str(obsm_use))
 
 # L.info("Computing nn using hnswlib as implemented in the pegasus package")
 

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -119,8 +119,8 @@ L.info( "Computing neighbors based on obsm: " + str(obsm_use))
 #             full_speed=args.full-speed)
 
 if args.method == "scanpy":
-    from scanpy.pp import neighbors
-    neighbors(adata,
+    import scanpy as sc
+    sc.pp.neighbors(adata,
               n_neighbors = args.k,
               metric = args.metric,
               use_rep = obsm_use)

--- a/python/run_cluster.py
+++ b/python/run_cluster.py
@@ -84,7 +84,9 @@ elif args.algorithm == "louvain":
 else:
     raise ValueError("Clustering algorithm not recognised")
 
-adata.obs.to_csv(os.path.join(args.outdir,
-                          "scanpy.clusters.tsv.gz"), sep="\t", index=False)
+select_cols = ['barcode', args.algorithm]
+adata.obs[select_cols].to_csv(os.path.join(args.outdir,
+                                           "scanpy.clusters.tsv.gz"),
+                              sep="\t", index=False)
 
 L.info("Complete")

--- a/python/run_phate.py
+++ b/python/run_phate.py
@@ -60,11 +60,8 @@ parser.add_argument("--input_type", default="tsv", type=str,
 
 args = parser.parse_args()
 
-# ########################################################################### #
-# ############## Create outdir and set results file ######################### #
-# ########################################################################### #
-
-
+L.info("Running with arguments:")
+print(args)
 
 
 # ########################################################################### #
@@ -74,7 +71,7 @@ args = parser.parse_args()
 if args.input_type == "tsv":
     if args.assay == "reduced.dimensions":
         # Read matrix of reduced dimensions, create anndata and add dimensions
-        pd.read_csv(args.data, sep="\t", header=0)
+        data = pd.read_csv(args.data, sep="\t", header=0)
 
     if args.assay == "scaled.data":
         # Read matrix of reduced dimensions, create anndata and add dimensions


### PR DESCRIPTION
- add optional usage of 'begin.h5seurat' as input instead of 'begin.rds', for this the package [SeuratDisk](https://mojaveazure.github.io/seurat-disk/) is used
- new option in yml for this: input_format = rds | h5seurat , this option is used for multiple tasks throughout the pipeline_seurat.py
- for option 'h5seurat': instead of writing out flat files for e.g. scaled data or metadata, the begin.h5seurat is converted to an anndata object (begin.h5ad) and this is used for other tasks (new R script for this)

- fixes to code for diffusion map task (was running only once per components not for each cluster resolution?)
- test done for following combinations: from h5seurat + loom velocity, from rds + loom velocity, from raw mm format using h5seurat 
