### PR TITLE
KJ: fix known markers violins

### DIFF
--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -102,9 +102,9 @@ for(group in unique(genes$group))
 
     if("plot_name" %in% colnames(genes))
     {
-        plot_names <- make.unique(paste(tmp$plot_name," (",tmp$gene_name,")",sep=""))
+        plot_names <- make.unique(paste(tmp$plot_name," (",tmp$gene,")",sep=""))
     } else {
-        plot_names <- make.unique(tmp$gene_name)
+        plot_names <- make.unique(tmp$gene)
     }
     tmp$plot_name <- plot_names
 

--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -1231,16 +1231,14 @@ def diffusionMap(infile, outfile):
 
 @active_if(PARAMS["run_knownmarkers"])
 @transform(cluster,
-           regex(r"(.*)/cluster.dir/cluster.sentinel"),
-           r"\1/known.markers.dir/known.markers.sentinel")
+           regex(r"(.*)/(.*)/(.*)/cluster.sentinel"),
+           r"\1/\2/\3/known.markers.dir/known.markers.sentinel")
 def knownMarkerViolins(infile, outfile):
     '''
        Make per-cluster violin plots from a given set of known marker genes.
     '''
 
     spec, SPEC = TASK.get_vars(infile, outfile, PARAMS)
-
-    cluster_ids = os.path.join(spec.indir, "cluster_ids.rds")
 
     if not os.path.exists(PARAMS["knownmarkers_file"]):
         raise ValueError("The specified known markers file does not exist")

--- a/pipelines/pipeline_seurat/pipeline.yml
+++ b/pipelines/pipeline_seurat/pipeline.yml
@@ -577,7 +577,7 @@ knownmarkers:
   # main report as violin plots.
   #
   # tab-delimited .txt files with columns:
-  # gene_id, gene_name, group
+  # gene_id, gene, group
   file:
 
 # FindMarkers parameters

--- a/tenxutils/R/ViolinPlots.R
+++ b/tenxutils/R/ViolinPlots.R
@@ -138,8 +138,6 @@ makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
                    strip.background = element_rect(fill="grey94",color="grey94"),
                    panel.spacing.x=unit(2, "mm"),
                    axis.line.y = element_blank())
-  #  axis.title.x = element_blank())
-  gp <- gp + annotate("segment", x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
 
   gpGrob <- ggplotGrob(gp)
 

--- a/tenxutils/R/ViolinPlots.R
+++ b/tenxutils/R/ViolinPlots.R
@@ -139,6 +139,13 @@ makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
                    panel.spacing.x=unit(2, "mm"),
                    axis.line.y = element_blank())
 
+  if (to_add > 0){
+    ggData$gene <- droplevels(ggData$gene)
+    gp <- gp + geom_segment(data=ggData, x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
+  } else {
+    gp <- gp + annotate("segment", x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
+  }
+  
   gpGrob <- ggplotGrob(gp)
 
   if(nl < ncol) {

--- a/tenxutils/R/ViolinPlots.R
+++ b/tenxutils/R/ViolinPlots.R
@@ -139,13 +139,9 @@ makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
                    panel.spacing.x=unit(2, "mm"),
                    axis.line.y = element_blank())
 
-  if (to_add > 0){
-    ggData$gene <- droplevels(ggData$gene)
-    gp <- gp + geom_segment(data=ggData, x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
-  } else {
-    gp <- gp + annotate("segment", x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
-  }
-  
+  ggData$gene <- droplevels(ggData$gene)
+  gp <- gp + geom_segment(data=ggData, x=-Inf, xend=-Inf, y=-Inf, yend=Inf,size=1)
+
   gpGrob <- ggplotGrob(gp)
 
   if(nl < ncol) {


### PR DESCRIPTION
Following issues occurred:
(1) The pipeline task for known marker violin plots was not connected properly, therefore no plots were produced (no error either)
(2) The description in the yml file for the input file for known markers did not match the expected columns (gene_name vs gene)
(3) annotate command within makeViolins was producing this error (ggplot2 v3.3.2): `Error in seq.default(a, b, length.out = n + 1) : 
  'from' must be a finite number` . This issue seems to be caused by the presence of 'empty' facets. Now fixed by dropping the empty levels prior to drawing the segment if required.

Overall, the Violins.R script in tenxutils seems to only be used for the known markers. This could maybe be switched to use the plotViolins/violinPlotSection in Plot.R, @snsansom ?