### PR TITLE
fix typo in exportForPython task

### DIFF
--- a/pipelines/pipeline_seurat.py
+++ b/pipelines/pipeline_seurat.py
@@ -718,7 +718,7 @@ def exportForPython(infile, outfile):
         source_files = ["embedding.*.tsv.gz",
                         "export_for_python.*",
                         "metadata.tsv.gz",
-                        "feaatures.tsv.gz",
+                        "features.tsv.gz",
                         "barcodes.tsv.gz",
                         "assay.*.data.tsv.gz",
                         "sig_comps.tsv"]


### PR DESCRIPTION
This typo results in failure of the velocity task if headstart is used (as features.tsv.gz is not linked correctly).