### PR TITLE
Fix issue with scvelo and use of all.equal

### DIFF
--- a/R/seurat_FindMarkers.R
+++ b/R/seurat_FindMarkers.R
@@ -103,7 +103,7 @@ if(!have_gene_ids)
 
 xx <- names(cluster_ids)
 yy <- colnames(x=s)
-if(!all.equal(xx[order(xx)], yy[order(yy)])) {
+if(!isTRUE(all.equal(xx[order(xx)], yy[order(yy)]))) {
     stop("cluster_ids and seurat object have different cells")
 }
 

--- a/R/seurat_clusterStats.R
+++ b/R/seurat_clusterStats.R
@@ -57,7 +57,7 @@ cluster_ids <- readRDS(opt$clusterids)
 
 xx <- names(cluster_ids)
 yy <- colnames(x=s)
-if(!all.equal(xx[order(xx)], yy[order(yy)])) {
+if(!isTRUE(all.equal(xx[order(xx)], yy[order(yy)]))) {
     stop("cluster_ids and seurat object have different cells")
 }
 


### PR DESCRIPTION
- pandas .loc indexing no longer supports missing keys (see:
  https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-with-list-with-missing-labels-is-deprecated
  so run_scvelo.py is refactored to first subset the velocity matrices
  to match the cells retained by the pipeline after clustering.

- use of (!all.equal) is corrected to !isTRUE(all.equal) (with thanks to
  Michael Ng).

The pipelines have been installed and tested (on the three example datasets)
in a clean python (3.7.3) virtual environment and with a fresh R 4.0.0 package
library.