### PR TITLE
Fix compatibility with Seurat v4

### DIFF
--- a/R/plot_violins.R
+++ b/R/plot_violins.R
@@ -60,7 +60,7 @@ genes <- read.table(opt$genetable,
 
 ## read in the raw count matrix
 s <- readRDS(opt$seuratobject)
-Idents(s) <- readRDS(opt$clusterids)
+Idents(s) <- readRDS(opt$clusterids)[Cells(s)]
 
 ## set the default assay
 message("Setting default assay to: ", opt$seuratassay)

--- a/R/seurat_FindMarkers.R
+++ b/R/seurat_FindMarkers.R
@@ -79,7 +79,7 @@ plan("multiprocess",
 
 
 s <- readRDS(opt$seuratobject)
-cluster_ids <- readRDS(opt$clusterids)
+cluster_ids <- readRDS(opt$clusterids)[Cells(s)]
 
 have_gene_ids <- "gene_id" %in% colnames(s@misc)
 
@@ -281,16 +281,17 @@ for (conserved.level in levels(ident.conserved)){
         markers <- FindMarkers(s,
                                ident.1 = "a",
                                ident.2 = "b",
-                                        # genes.use = NULL,
+
                                logfc.threshold = opt$threshuse,
                                test.use = opt$testuse,
                                min.pct = opt$minpct,
                                min.diff.pct = opt$mindiffpct,
-                                        # print.bar = F,
+
                                min.cells.feature = min.cells,
                                min.cells.group = min.cells,
 
-                               max.cells.per.ident=opt$maxcellsperident)
+                               max.cells.per.ident=opt$maxcellsperident,
+                               base = exp(1))
 
         print(head(markers))
         ## keep everything, adjust later

--- a/R/seurat_characteriseClusterDEGenes.R
+++ b/R/seurat_characteriseClusterDEGenes.R
@@ -189,7 +189,7 @@ tex <- c(tex, getFigureTex(defn, deCaption,plot_dir_var=opt$plotdirvar))
 ## read in the seurat object
 s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
+Idents(s) <- cluster_ids[Cells(s)]
 
 ## set the default assay
 message("Setting default assay to: ", opt$seuratassay)

--- a/R/seurat_clusterStats.R
+++ b/R/seurat_clusterStats.R
@@ -61,7 +61,7 @@ if(!isTRUE(all.equal(xx[order(xx)], yy[order(yy)]))) {
     stop("cluster_ids and seurat object have different cells")
 }
 
-cluster_ids <- cluster_ids[colnames(x = s)]
+cluster_ids <- cluster_ids[Cells(s)]
 
 if(!identical(colnames(x = s),names(cluster_ids)))
 {   stop("Cluster cell names do not match Seurat object cell names")
@@ -109,7 +109,7 @@ if(opt$conservedfactor != "none"){
 message("Setting default assay to: ", opt$seuratassay)
 DefaultAssay(s) <- opt$seuratassay
 
-message("seurat_FindMarkers.R running with default assay: ", DefaultAssay(s))
+message("seurat_clusterStats.R running with default assay: ", DefaultAssay(s))
 
 stats.list <- list()
 

--- a/R/seurat_cluster_marker_plots.R
+++ b/R/seurat_cluster_marker_plots.R
@@ -94,7 +94,7 @@ outprefix = file.path(opt$outdir,paste("cluster",opt$cluster,sep="."))
 
 # read in the Seurat object
 s <- readRDS(opt$seuratobject)
-Idents(s) <- readRDS(opt$clusterids)
+Idents(s) <- readRDS(opt$clusterids)[Cells(s)]
 
 message("Setting default assay to: ", opt$seuratassay)
 DefaultAssay(s) <- opt$seuratassay

--- a/R/seurat_compare_clusters.R
+++ b/R/seurat_compare_clusters.R
@@ -41,7 +41,7 @@ s <- readRDS(opt$seuratobject)
 
 message("seurat_cluster.R running with default assay: ", DefaultAssay(s))
 
-Idents(s) <- readRDS(opt$clusterids)
+Idents(s) <- readRDS(opt$clusterids)[Cells(s)]
 
 print(Idents(s))
 

--- a/R/seurat_dm.R
+++ b/R/seurat_dm.R
@@ -52,7 +52,7 @@ print(opt)
 message("readRDS")
 s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
+Idents(s) <- cluster_ids[Cells(s)]
 
 message("seurat_dm.R running with default assay: ", DefaultAssay(s))
 

--- a/R/seurat_summariseMarkers.R
+++ b/R/seurat_summariseMarkers.R
@@ -41,7 +41,7 @@ cat("Running with options:\n")
 print(opt)
 
 s <- readRDS(opt$seuratobject)
-cluster_ids <- readRDS(opt$clusterids)
+cluster_ids <- readRDS(opt$clusterids)[Cells(s)]
 Idents(s) <- cluster_ids
 
 message("Setting default assay to: ", opt$seuratassay)

--- a/R/seurat_topMarkerHeatmap.R
+++ b/R/seurat_topMarkerHeatmap.R
@@ -44,7 +44,7 @@ print(opt)
 
 s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
+Idents(s) <- cluster_ids[Cells(s)]
 
 message("Setting default assay to: ", opt$seuratassay)
 DefaultAssay(s) <- opt$seuratassay

--- a/R/seurat_tsne.R
+++ b/R/seurat_tsne.R
@@ -48,7 +48,7 @@ print(opt)
 message("readRDS")
 s <- readRDS(opt$seuratobject)
 cluster_ids <- readRDS(opt$clusterids)
-Idents(s) <- cluster_ids
+Idents(s) <- cluster_ids[Cells(s)]
 print(head(Idents(s)))
 
 message("seurat_tsne.R running with default assay: ", DefaultAssay(s))

--- a/python/make_anndata.py
+++ b/python/make_anndata.py
@@ -36,7 +36,7 @@ parser.add_argument("--outdir",default=1, type=str,
 parser.add_argument("--comps", default="1", type=str,
                     help="Number of dimensions to include in the knn computation")
 parser.add_argument("--method", default="scanpy", type=str,
-                    help="scanpy|hnsw (scanpy uses pynndescent)")
+                    help="scanpy|hnsw|sklearn (scanpy uses pynndescent)")
 parser.add_argument("--k", default=20, type=int,
                     help="number of neighbors")
 parser.add_argument("--metric", default="euclidean", type=str,
@@ -126,6 +126,25 @@ elif args.method == "hnsw":
                              "ef":200,
                              "ef_construction":200},
               num_threads=num_threads)
+
+
+elif args.method == "sklearn":
+
+    L.info("Computing neighbors using sklearn")
+    # we use the neighbors function from scvelo
+
+    from scvelo.pp import neighbors
+
+    neighbors(adata,
+              n_neighbors = args.k,
+              n_pcs = None,
+              use_rep = "X_rdims",
+              knn = True,
+              random_state = 0,
+              method = 'sklearn',
+              metric = args.metric,
+              # metric_kwds = {}
+              num_threads=args.threads)
 
 
 else:

--- a/tenxutils/R/ViolinPlots.R
+++ b/tenxutils/R/ViolinPlots.R
@@ -74,6 +74,7 @@ removeGrobs <- function(gpGrob, ncol, nmissing)
 #' @param colors A vector of (fill) colors, one per cluster.
 #' @param alpha Alpha value for the fill color
 #' @param clusters Optional list of clusters to plot
+#' @param cluster_labels Optional named vector containing cluster labels
 #' @param xlab The label for the x axis.
 #'
 #' @export
@@ -81,7 +82,7 @@ removeGrobs <- function(gpGrob, ncol, nmissing)
 makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
                         colors=NULL,
                         alpha=1,
-                        clusters=NULL,
+                        clusters=NULL, cluster_labels=NULL,
                         xlab=NULL)
 {
   require(ggplot2)
@@ -98,8 +99,6 @@ makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
     cluster_levels <- unique(clusters)
   }
 
-  ggData$cluster <- factor(ggData$cluster,
-                           levels=cluster_levels)
 
 
   nl  <- length(levels(ggData$gene))
@@ -107,6 +106,16 @@ makeViolins <- function(ggData, title=NULL, ncol=8, group=NULL,
 
   if(nl < ncol) { to_add <- (ncol - nl) } else { to_add <- 0 }
 
+  if(!is.null(cluster_labels))
+  {
+    ggData$cluster <- factor(cluster_labels[as.character(ggData$cluster)],
+                             levels=rev(as.character(cluster_labels)))
+  } else {
+    
+    ggData$cluster <- factor(ggData$cluster,
+                             levels=cluster_levels)
+  }
+  
   if(to_add > 0)
   {
     ggData$gene <- factor(ggData$gene,
@@ -175,6 +184,7 @@ plotGrob <- function(ggGrob)
 #' @param xlab The label for the x axis.
 #' @param group A column in the seurat "meta.data" slot on which to group plots by.
 #' @param colors A vector of (fill) colors, one per cluster.
+#' @param cluster_labels A named vector of cluster labels
 #' @param alpha Alpha level for the fill color.
 #' @param plot If set to FALSE the grob is returned instead.
 #'
@@ -183,6 +193,7 @@ plotGrob <- function(ggGrob)
 plotHorizontalViolins <- function(seurat_object,
                                   genes,
                                   clusters=NULL,
+                                  cluster_labels=NULL,
                                   title=NULL,
                                   ncol=8,
                                   xlab="normalised expression level",
@@ -207,6 +218,7 @@ plotHorizontalViolins <- function(seurat_object,
                         ncol=ncol,
                         xlab=xlab,
                         clusters=clusters,
+                        cluster_labels=cluster_labels,
                         group=group,
                         colors=colors,
                         alpha=alpha)


### PR DESCRIPTION
1. For the log fold-change issue we now explicitly set the default base in FindMarkers to match the previous default. The pipeline already converts to base 2 where it makes sense for plotting. 

2. We now ensure that cluster_ids are added to the seurat object in the correct order.

3. This also adds support for use of sklearn to compute exact neighbour graphs.

4. The makeViolins function (tenxutils/R/ViolinPlots.R) now accepts a cluster_labels argument.

Tested with the latest version of Seurat on KGen and BRMC clusters (infb dataset). 